### PR TITLE
Add config file parameter to dspi command

### DIFF
--- a/docs/ZWO/index.html
+++ b/docs/ZWO/index.html
@@ -699,9 +699,15 @@ TELGUIDE= '10'
 <dt><b>exit</b>  </dt>
 <dd>Close the GUI immediately (without a confirmation dialog box). </dd>
 <p>
-<!--
+<dt><b>dspi</b> [config_name] </dt>
+<dd>Restart the acquisition with optional configuration file. </dd>
+<dd>Without parameter: restart with current configuration. </dd>
+<dd>With parameter: load the specified .ini config file (e.g., <code>dspi mage</code> loads <code>mage.ini</code>) and restart acquisition. </dd>
+<dd>Shows an error message if the config file doesn't exist. </dd>
 <dt><b>reset</b>  </dt>
-<dd>  </dd>
+<dd>Same as <b>dspi</b> (alias for restart acquisition). </dd>
+<p>
+<!--
 <dt><b>reboot</b>  </dt>
 <dd>  </dd>
 <p>

--- a/docs/ZWO/zwogcam.html
+++ b/docs/ZWO/zwogcam.html
@@ -699,9 +699,15 @@ TELGUIDE= '10'
 <dt><b>exit</b>  </dt>
 <dd>Close the GUI immediately (without a confirmation dialog box). </dd>
 <p>
-<!--
+<dt><b>dspi</b> [config_name] </dt>
+<dd>Restart the acquisition with optional configuration file. </dd>
+<dd>Without parameter: restart with current configuration. </dd>
+<dd>With parameter: load the specified .ini config file (e.g., <code>dspi mage</code> loads <code>mage.ini</code>) and restart acquisition. </dd>
+<dd>Shows an error message if the config file doesn't exist. </dd>
 <dt><b>reset</b>  </dt>
-<dd>  </dd>
+<dd>Same as <b>dspi</b> (alias for restart acquisition). </dd>
+<p>
+<!--
 <dt><b>reboot</b>  </dt>
 <dd>  </dd>
 <p>

--- a/docs/ZWO/zwoguider.html
+++ b/docs/ZWO/zwoguider.html
@@ -699,9 +699,15 @@ TELGUIDE= '10'
 <dt><b>exit</b>  </dt>
 <dd>Close the GUI immediately (without a confirmation dialog box). </dd>
 <p>
-<!--
+<dt><b>dspi</b> [config_name] </dt>
+<dd>Restart the acquisition with optional configuration file. </dd>
+<dd>Without parameter: restart with current configuration. </dd>
+<dd>With parameter: load the specified .ini config file (e.g., <code>dspi mage</code> loads <code>mage.ini</code>) and restart acquisition. </dd>
+<dd>Shows an error message if the config file doesn't exist. </dd>
 <dt><b>reset</b>  </dt>
-<dd>  </dd>
+<dd>Same as <b>dspi</b> (alias for restart acquisition). </dd>
+<p>
+<!--
 <dt><b>reboot</b>  </dt>
 <dd>  </dd>
 <p>

--- a/src/gcam/guider.c
+++ b/src/gcam/guider.c
@@ -113,8 +113,8 @@ static void run_guider1(void* param)
   double next_eds=0;
   double r0=1,a0=0,n0=0;               /* gm5 stuff v0416 */
   int    gm5_locked=0;
-  int    ix,iy,ppix=0,vrad=0,npix=0,doit=1;
-  u_int  seqNumber=0,counter=0;
+  int    ix,iy,ppix=0,vrad=0,npix=0;
+  u_int  seqNumber=0;
   Pixel  *pbuf=NULL;
   Guider *g = (Guider*)param;
   QlTool *qltool = g->qltool;
@@ -267,7 +267,6 @@ static void run_guider1(void* param)
         g->azerp = azerr;              /* store last error */
         g->elerp = elerr;
         qltool->guiding = abs(qltool->guiding);
-        counter++; doit=1;
 	//	if (server->rolling && (walltime(0) < next_eds)) {
 	//          if (counter % server->rolling) doit = 0;
 	//}
@@ -510,7 +509,8 @@ static int tcs_recon(Guider *g)        /* v0417 */
   char buf[128];
 #if (DEBUG > 0)
   fprintf(stderr,"%s(%p)\n",__func__,g);
-  tdebug(__func__,g);
+  sprintf(buf,"tcs_recon(%p)",g);
+  tdebug(__func__,buf);
 #endif
 
   int err = telio_open(2);

--- a/src/gcam/zwogcam.c
+++ b/src/gcam/zwogcam.c
@@ -1640,6 +1640,8 @@ static int handle_command(Guider* g,const char* command,int showMsg)
       if (read_inifile(g,inifile) < 0) {
         sprintf(msgstr,"config file '%s' not found",inifile);
         err = -1;
+      } else {                         /* update server host from config */
+        strcpy(g->server->host,g->host);
       }
     }
     if (!err && g->init_flag >= 0) thread_detach(run_init,g);

--- a/src/gcam/zwogcam.c
+++ b/src/gcam/zwogcam.c
@@ -1750,11 +1750,7 @@ static void* run_setup(void* param)
   g->init_flag = -1;                   /* init running */
   message(g,PREFUN,MSS_INFO);
 
-#if 1 // todo ?Povilas
-  sprintf(buf,"%s (%d) - v%s",g->host,g->gnum,P_VERSION); // v0419
-#else
-  sprintf(buf,"%s (%d) - v%s",g->server->modelName,g->gnum,P_VERSION);
-#endif
+  sprintf(buf,"%s %s (%d) - v%s",g->name,g->host,g->gnum,P_VERSION);
   CBX_SetMainWindowName(&mwin,buf);
 
   long err = zwo_setup(g->server,baseD,baseB,g->offx,g->offy);

--- a/src/gcam/zwogcam.c
+++ b/src/gcam/zwogcam.c
@@ -2287,7 +2287,7 @@ static void make_mask(Guider *g,const char* par)  /* v0319 */
   assert(server->mask);
   assert(server->aoiW == server->aoiH);
   int npix = server->aoiW * server->aoiH;
-  sprintf(file,"%s/%s",genv2("GCAMZWOPATH","/opt/gcamzwo"),mask_name(g,name));
+  sprintf(file,"%s/%s",genv2("GCAMZWOPATH", "/opt/gcamzwo"),mask_name(g,name));
 
   if (!strcmp(par,"off")) {            /* turn OFF mask */
     memset(server->mask,0,npix*sizeof(char));
@@ -2338,7 +2338,7 @@ static void make_mask(Guider *g,const char* par)  /* v0319 */
 
   FILE *fp = fopen(file,"w");
   if (!fp) {
-    sprintf(buf,"failed to write ~/%s",name); 
+    sprintf(buf,"failed to write %s",file);
     message(g,buf,MSS_WARN);
   } else {
     fwrite(mask,sizeof(char),npix,fp);

--- a/src/gcam/zwogcam.c
+++ b/src/gcam/zwogcam.c
@@ -1649,13 +1649,15 @@ static int handle_command(Guider* g,const char* command,int showMsg)
         err = -1;
       } else {                         /* update server host from config */
         strcpy(g->server->host,g->host);
-        if (g->server->mask) {         /* force mask reload */
-          free(g->server->mask);
-          g->server->mask = NULL;
-        }
       }
     }
-    if (!err && g->init_flag >= 0) thread_detach(run_init,g);
+    if (!err) {
+      if (g->server->mask) {           /* force mask reload */
+        free(g->server->mask);
+        g->server->mask = NULL;
+      }
+      if (g->init_flag >= 0) thread_detach(run_init,g);
+    }
   } else                               /* shutdown server */
   if (!strncasecmp(cmd,"shutdown",4) || !strncasecmp(cmd,"poweroff",5)) {
     if (g->loop_running) do_stop(g,3000);
@@ -2251,6 +2253,8 @@ static void load_mask(Guider *g)       /* v0322 */
   int npix = server->aoiW * server->aoiH;
   assert(server->aoiW == server->aoiH);
   sprintf(file,"%s/%s",genv2("GCAMZWOPATH", "/opt/gcamzwo"),mask_name(g,name));
+  printf("load_mask: loading %s (serial=%s, aoiW=%d, offx=%d, offy=%d)\n",
+         file, server->serialNumber, server->aoiW, g->offx, g->offy);
 
   FILE *fp = fopen(file,"r");
   if (!fp) { 

--- a/src/gcam/zwogcam.c
+++ b/src/gcam/zwogcam.c
@@ -315,6 +315,7 @@ int main(int argc,char **argv)
     .slitW = 6,                   /* PFS:6, MIKE:13 */
     .px = 0.051,                  /* PFS:53, MIKE:54 */
     .lmag = 0,
+    .name = "",
     .bx = 0,
     .pct = 0,
     .bkg = 0,
@@ -460,9 +461,6 @@ int main(int argc,char **argv)
   /* Initialize single guider */
   {
     Guider *g = &sGuider;
-    if (strlen(g->name) == 0) {
-      sprintf(g->name,"gCam%d",g->gnum);
-    }
     g->server = zwo_create(g->host,SERVER_PORT);
     g->server->expTime = g->status.exptime;
     g->gid = 0;                        /* guiding thread ID */
@@ -1644,6 +1642,7 @@ static int handle_command(Guider* g,const char* command,int showMsg)
     if (n > 1) {                       /* load config file if specified */
       char inifile[256];
       sprintf(inifile,"%s.ini",par1);
+      strncpy(g->name, "", sizeof(g->name));               /* reset name to avoid confusion */
       if (read_inifile(g,inifile) < 0) {
         sprintf(msgstr,"config file '%s' not found",inifile);
         err = -1;

--- a/src/gcam/zwogcam.c
+++ b/src/gcam/zwogcam.c
@@ -300,30 +300,37 @@ int main(int argc,char **argv)
   pthread_mutex_init(&scanMutex,NULL);
   pthread_mutex_init(&mesgMutex,NULL);
 
-  sGuider.gnum = 1;                    /* PR */
-  sGuider.gmode = 0; 
-  sGuider.gmpar = 't';
-  sGuider.angle = -120.0;              /* PFS:-128, MIKE:-119 */
-  sGuider.elsign = -1.0;
-  sGuider.rosign =  0.0;
-  sGuider.parity =  -1.0;
-  sGuider.parit2 =  1.0;
-  sGuider.offx = sGuider.offy = 0;     /* PFS:-10+85, MIKE:+45+230 */
-  sGuider.slitW = 6;                   /* PFS:6, MIKE:13 */
-  sGuider.px = 0.051;                  /* PFS:53, MIKE:54 */
-  sGuider.lmag = sGuider.bx = 0;
-  sGuider.pct = sGuider.bkg = sGuider.span = 0;
-  strcpy(sGuider.send_host, "localhost");
-  sGuider.send_port = 0;
-  strcpy(sGuider.host, "localhost");
-  sGuider.rPort = 0;
-  sGuider.sens = 0.5f;
-  sGuider.status.exptime = 1.0f;
+  /* Initialize sGuider with struct initializer for clarity */
+  sGuider = (Guider){
+    .gnum = 1,
+    .gmode = 0,
+    .gmpar = 't',
+    .angle = -120.0,              /* PFS:-128, MIKE:-119 */
+    .elsign = -1.0,
+    .rosign = 0.0,
+    .parity = -1.0,
+    .parit2 = 1.0,
+    .offx = 0,                    /* PFS:-10+85, MIKE:+45+230 */
+    .offy = 0,
+    .slitW = 6,                   /* PFS:6, MIKE:13 */
+    .px = 0.051,                  /* PFS:53, MIKE:54 */
+    .lmag = 0,
+    .bx = 0,
+    .pct = 0,
+    .bkg = 0,
+    .span = 0,
+    .send_host = "localhost",
+    .send_port = 0,
+    .host = "localhost",
+    .rPort = 0,
+    .sens = 0.5f,
+    .status.exptime = 1.0f,
 #ifdef ENG_MODE
-  strcpy(sGuider.gain,"");
+    .gain = "",
 #else
-  strcpy(sGuider.gain,"hi");
+    .gain = "hi",
 #endif
+  };
 
   { extern char *optarg; double f;     /* parse command line */  
     extern int opterr,optopt; opterr=0;

--- a/src/gcam/zwogcam.c
+++ b/src/gcam/zwogcam.c
@@ -69,6 +69,7 @@
  * v1.0.4  2025-12-11  on fone turn of eds guider eds flag 801, and set gdrbox message black.
  * v1.0.4  2026-01-15  added exptime to config file
  * v1.0.4  2026-01-15  added mouse-mode aliases, updated documentation
+ * v1.0.5  starting on v1.0.5, updates are documented in the release notes on github
  *
  * http://www.lco.cl/telescopes-information/magellan/
  *   operations-homepage/magellan-control-system/magellan-code/gcam
@@ -1633,7 +1634,15 @@ static int handle_command(Guider* g,const char* command,int showMsg)
     make_mask(g,par1);
   } else                               /* reset server */
   if (!strcasecmp(cmd,"dspi") || !strcasecmp(cmd,"reset")) {
-    if (g->init_flag >= 0) thread_detach(run_init,g);
+    if (n > 1) {                       /* load config file if specified */
+      char inifile[256];
+      sprintf(inifile,"%s.ini",par1);
+      if (read_inifile(g,inifile) < 0) {
+        sprintf(msgstr,"config file '%s' not found",inifile);
+        err = -1;
+      }
+    }
+    if (!err && g->init_flag >= 0) thread_detach(run_init,g);
   } else                               /* shutdown server */
   if (!strncasecmp(cmd,"shutdown",4) || !strncasecmp(cmd,"poweroff",5)) {
     if (g->loop_running) do_stop(g,3000);

--- a/src/gcam/zwogcam.c
+++ b/src/gcam/zwogcam.c
@@ -1642,6 +1642,10 @@ static int handle_command(Guider* g,const char* command,int showMsg)
         err = -1;
       } else {                         /* update server host from config */
         strcpy(g->server->host,g->host);
+        if (g->server->mask) {         /* force mask reload */
+          free(g->server->mask);
+          g->server->mask = NULL;
+        }
       }
     }
     if (!err && g->init_flag >= 0) thread_detach(run_init,g);

--- a/src/gcam/zwogcam.h
+++ b/src/gcam/zwogcam.h
@@ -5,7 +5,7 @@
  * ---------------------------------------------------------------- */
 
 #define PROJECT_ID      22             /* andorgui / zwogcam */
-#define P_VERSION       "1.0.5"
+#define P_VERSION       "1.0.6"
 
 extern void message(const void*,const char*,int);
 


### PR DESCRIPTION
This PR enhances the `dspi` command to accept an optional configuration file parameter.

## Changes
- `dspi` now accepts an optional config file name (e.g., `dspi mage` loads `mage.ini`)
- Automatically appends `.ini` extension to the parameter
- Loads the specified config file before restarting acquisition
- Shows an error message if the config file doesn't exist
- Documentation updated in `docs/ZWO/zwogcam.html`

## Usage
- `dspi` - restarts acquisition with current configuration
- `dspi mage` - loads `mage.ini` and restarts acquisition
- `dspi mike` - loads `mike.ini` and restarts acquisition