### PR TITLE
Per-frame timestamps + ASI SDK 1.41 (ASI715MC support)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get install -y libusb-1.0-0-dev
 COPY . /app/zwo
 
 ## ASI SDK
-RUN cd /app/zwo/docs/ZWO/Setup/ && tar jxvf ASI_linux_mac_SDK_V1.20.2.tar.bz2 && cd ASI_linux_mac_SDK_V1.20.2/lib 
-RUN cp /app/zwo/docs/ZWO/Setup/ASI_linux_mac_SDK_V1.20.2/lib/armv8/libASICamera2.so.1.20.2 /usr/local/lib
-RUN cd /app/zwo/docs/ZWO/Setup/ASI_linux_mac_SDK_V1.20.2/lib/ && install asi.rules /lib/udev/rules.d
-RUN cd /usr/local/lib && ln -s libASICamera2.so.1.20.2 libASICamera2.so
+RUN cd /app/zwo/docs/ZWO/Setup/ && tar jxvf ASI_linux_mac_SDK_V1.41.tar.bz2 && cd ASI_linux_mac_SDK_V1.41/lib
+RUN cp /app/zwo/docs/ZWO/Setup/ASI_linux_mac_SDK_V1.41/lib/armv8/libASICamera2.so.1.41 /usr/local/lib
+RUN cd /app/zwo/docs/ZWO/Setup/ASI_linux_mac_SDK_V1.41/lib/ && install asi.rules /lib/udev/rules.d
+RUN cd /usr/local/lib && ln -s libASICamera2.so.1.41 libASICamera2.so
 ## EFW SDK
 RUN cd /app/zwo/docs/ZWO/Setup/ && tar jxvf EFW_linux_mac_SDK_V1.7.tar.bz2 && cd EFW_linux_mac_SDK_V1.7/lib
 RUN cp /app/zwo/docs/ZWO/Setup/EFW_linux_mac_SDK_V1.7/lib/armv8/libEFWFilter.so.1.7 /usr/local/lib

--- a/docs/ASI294MM-P_200Hz_ROI_report.md
+++ b/docs/ASI294MM-P_200Hz_ROI_report.md
@@ -1,0 +1,121 @@
+# ZWO ASI294MM Pro at 200 Hz — small-ROI streaming test for fast tip-tilt
+
+**Date:** 2026-07-08
+**Camera:** ZWO ASI294MM Pro (mono, 8288×5644, 12-bit ADC), SDK 1.20.2
+**Server:** `zwoserver` on Raspberry Pi 4 (USB3 to camera), gigabit Ethernet
+**Client:** Raspberry Pi (`zwo-bootsrv`), same gigabit LAN, RTT 0.32 ms
+**Tool:** `src/benchmark/zwo_benchmark` (C client, video mode: `start` → `next` loop → `stop`)
+
+## Question
+
+Can we acquire with the full detector, then stream a small window around
+the guide star **as close to 200 Hz as possible**, for tip-tilt / ground
+layer PSD studies? Is the limit the 1 Gbps link, or is there per-frame
+overhead when cutting an ROI?
+
+All rates below are **end-to-end at the client** (what a tip-tilt loop
+would actually see), not camera-internal rates. Every frame is verified
+by the server's sequence counter, so drops are counted exactly.
+
+## Answer in one line
+
+**Yes at bin 2: a window up to ~200×140 (binned pixels) streams at
+192–194 Hz with zero dropped frames.** Bin 1 tops out at ~105 Hz even
+for an 80×56 window. The limit is camera/USB readout, not the network.
+
+## Measured frame-rate ceilings vs window size
+
+Exposure short enough not to matter (0.5–5 ms); 8-bit; each config
+measured for 5–20 s; `drops` = frames the camera produced but the
+client never received (seq gaps).
+
+| window (binned px) | sensor FOV (px) | bin 1 | bin 2 | drops |
+|---|---|---|---|---|
+| 40×28    | 80×56    | —        | **194 Hz** | 0 |
+| 80×56    | 160×112  | 105 Hz   | **194 Hz** | 0 |
+| 200×140  | 400×280  | —        | **193 Hz** | 0 |
+| 160×112  | 320×224  | 86 Hz    | —          | 0 |
+| 408×282  | 816×564  | 56 Hz    | 135 Hz     | 0 |
+| 824×564  | 1648×1128| 35 Hz    | —          | 0 |
+| 2072×1410| 4144×2820| 8.8 Hz¹  | 32 Hz      | 0 |
+
+¹ network-limited (103 MB/s); all other rows are camera-limited.
+
+At the 200 Hz target (5 ms exposure), bin 2 with a 200×140 window
+delivers **193 fps = 96.5% efficiency, zero drops**, sustained.
+
+## Frame-interval jitter at the operating point
+
+Per-frame arrival intervals (Δt) at bin 2, 200×140, 8-bit, 5 ms
+exposure, measured client-side over 20 s (~3900 frames):
+
+| statistic | value |
+|---|---|
+| mean Δt (core) | 5.19 ms → **192.6 Hz** |
+| σ (core) | **0.35 ms** |
+| p95 / p99 / max (core) | 5.5 / 5.6 / 6.3 ms |
+| stalls | **~366 ms, 2–5 per 20 s** (~0.1% of frames) |
+
+The core distribution is tight — 0.35 ms rms is small against a 5 ms
+frame period. However, the camera/USB/SDK side occasionally stalls for
+almost exactly 366 ms (a few times per minute; reproduced with all
+instrumentation local to the client, so it is not a network artifact;
+no frames are lost — delivery just pauses). A tip-tilt loop must
+tolerate these ~0.4 s gaps, and they will appear in PSDs as gaps or
+must be masked. Origin not yet identified (SDK-internal; possibly its
+exposure-control thread) — a follow-up item.
+
+## What sets the limits
+
+- **Not the network.** A bin 1 824×564 window moves only 16 MB/s at
+  its 35 Hz ceiling, on a link that sustains ~107 MB/s. The wire only
+  becomes the bottleneck above ~50% of the full frame.
+- **Readout scales with window height.** Bin 1 fits
+  `frame period ≈ 7.4 ms + 38 µs × rows`. Fewer rows → faster, down to
+  a floor.
+- **A ~5.15 ms/frame floor at bin 2** (the 194 Hz ceiling), identical
+  at 8-bit and 16-bit and independent of window size below ~200×140.
+  This is camera/USB-side (SDK default USB bandwidth = 40%).
+- **Bit depth is free** below the wire limit: 8-bit and 16-bit reach
+  identical frame rates (the USB link appears to always carry 16-bit
+  pixels). 16-bit is fine for centroiding if wanted.
+
+## Headroom / next steps
+
+- **`ASI_BANDWIDTHOVERLOAD` (USB bandwidth %, SDK default 40) is the
+  untested lever.** Raising it should shrink the per-row readout cost
+  and the 5.15 ms floor — likely the path to 200+ Hz at bin 1, and
+  >200 Hz at bin 2. Requires a small server addition (not yet exposed);
+  the benchmark is ready to sweep it.
+- `ASI_HIGH_SPEED_MODE` (10-bit ADC) is a second untested lever, at
+  some cost in bit depth.
+- The per-frame Δt series (benchmark `--verbose`) gives the timing
+  data needed for PSD work directly.
+
+## Server fixes made during this test (already deployed)
+
+Running at these rates exposed and fixed several issues in `zwoserver`
+on the Raspberry Pi — relevant to anyone reproducing this:
+
+1. **TCP_NODELAY**: sub-few-KB frames collapsed to ~23 Hz with 40 ms
+   Nagle/delayed-ACK stalls; now 194 Hz.
+2. **`next` poll quantum 5 ms → 1 ms**: removes 0–5 ms of per-frame
+   protocol jitter.
+3. **aarch64 memory-ordering race fixed**: the video thread published
+   buffer pointers without barriers; under fast command turnaround the
+   server segfaulted (confirmed by gdb). Benign on the old x86 host,
+   fatal on the Pi. Fixed with proper synchronization and validated
+   with 4 consecutive full sweeps (396 configs) with zero crashes.
+4. `Restart=on-failure` added to the systemd unit.
+
+## Reproducing
+
+```
+make -C src/server tcpip.o utils.o ptlib.o && make -C src/benchmark
+./zwo_benchmark --host <server> --bins 2 --bits 8 --rois 2,5,10 \
+    --exptimes 0.001,0.005 --duration 10 --csv out.csv
+```
+
+Full methodology, protocol details, and the complete sweep tables:
+[src/benchmark/README.md](../src/benchmark/README.md). Raw CSVs from
+all runs are on `zwo-bootsrv:~/zwo-benchmark/`.

--- a/docs/ASI294MM-P_200Hz_ROI_report.md
+++ b/docs/ASI294MM-P_200Hz_ROI_report.md
@@ -172,7 +172,7 @@ alignment between the two Pis). The literature is unanimous that
 NTP host timestamps cannot be trusted at the ms level without an
 independent optical check — see the plan and precedent (incl.
 proto-Lightspeed on Magellan Clay, ≤30 µs) in
-[two-camera-time-sync-verification.md](two-camera-time-sync-verification.md).
+[camera-time-sync-verification.md](camera-time-sync-verification.md).
 Open questions to close before trusting cross-camera correlation:
 
 1. Relative timestamp accuracy of the ASI294MM Pro when stamped

--- a/docs/ASI294MM-P_200Hz_ROI_report.md
+++ b/docs/ASI294MM-P_200Hz_ROI_report.md
@@ -1,6 +1,6 @@
 # ZWO ASI294MM Pro at 200 Hz — small-ROI streaming test for fast tip-tilt
 
-**Date:** 2026-07-08 (rev. 3: USB-bandwidth sweep, stall fix, high-speed-mode test)
+**Date:** 2026-07-08 (rev. 4: per-frame ns timestamps; true camera jitter = 0.059 ms rms)
 **Camera:** ZWO ASI294MM Pro (mono, 8288×5644, 12-bit ADC), SDK 1.20.2
 **Server:** `zwoserver` on Raspberry Pi 4 (USB3 to camera), gigabit Ethernet
 **Client:** Raspberry Pi (`zwo-bootsrv`), same gigabit LAN, RTT 0.32 ms
@@ -49,15 +49,36 @@ delivers **193 fps = 96.5% efficiency, zero drops**, sustained.
 
 ## Frame-interval jitter at the operating point
 
-Per-frame arrival intervals (Δt) at bin 2, 200×140, 8-bit, 5 ms
-exposure, measured client-side over 20 s (~3900 frames):
+Measured at bin 2, 200×140, 8-bit, 5 ms exposure, over 30 s
+(~5700 frames).
 
-| statistic | value |
-|---|---|
-| mean Δt (core) | 5.19 ms → **192.6 Hz** |
-| σ (core) | **0.35 ms** |
-| p95 / p99 / max (core) | 5.5 / 5.6 / 6.3 ms |
-| stalls | **~65 ms, one per 3–10 s** (was ~366 ms before the timeout fix below) |
+The server (protocol v1.0.5) now stamps every frame with a
+nanosecond-precision `CLOCK_REALTIME` timestamp taken the instant the
+SDK delivers it, returned in the `next` header. This separates the
+camera's true timing from protocol/network jitter (backwards
+compatible — existing clients ignore the extra field):
+
+| statistic (30 s @ 193 Hz) | client arrival (Δt) | server stamp (Δts) |
+|---|---|---|
+| mean interval | 5.19 ms | 5.20 ms |
+| σ (core) | 0.52 ms | **0.059 ms** |
+| stalls | ~66 ms | ~65.4 ms (identical frames) |
+
+**The camera's true delivery jitter is 59 µs rms** — an order of
+magnitude tighter than what client-side arrival times show. PSD work
+should use the per-frame timestamps directly; the 0.5 ms client-side
+scatter is protocol/network and disappears. Stalls (~65 ms, one per
+3–10 s; was ~366 ms before the timeout fix below) appear identically
+in both series and are precisely stamped, so masking them is exact.
+
+For cross-camera correlation the two guider hosts should share a
+clock discipline: NTP gives ~ms alignment; **PTP (`ptp4l` +
+`phc2sys`) brings it to tens of µs** on Pi-class hardware (software
+timestamping) and disciplines the same `CLOCK_REALTIME` the stamps
+read — no code change needed; switch the server's `TS_CLOCK` define
+to `CLOCK_TAI` on PTP hosts to be immune to leap-second steps. The
+stamp marks end-of-USB-delivery, a per-configuration constant offset
+from exposure start.
 
 The core distribution is tight — 0.35 ms rms is small against a 5 ms
 frame period. Frame delivery does stall a few times per minute
@@ -159,7 +180,10 @@ on the Raspberry Pi — relevant to anyone reproducing this:
    40–100, `ASI_HIGH_SPEED_MODE` 0/1).
 5. **`ASIGetVideoData` timeout floor 350 ms → 50 ms**: cuts the
    SDK lost-wakeup stalls from ~366 ms to ~65 ms.
-6. `Restart=on-failure` added to the systemd unit.
+6. **Per-frame ns timestamps** (v1.0.5): `next` returns
+   `"seq temp power ts_ns"`; backwards compatible (audited against
+   all existing clients).
+7. `Restart=on-failure` added to the systemd unit.
 
 ## Reproducing
 

--- a/docs/ASI294MM-P_200Hz_ROI_report.md
+++ b/docs/ASI294MM-P_200Hz_ROI_report.md
@@ -1,6 +1,6 @@
 # ZWO ASI294MM Pro at 200 Hz — small-ROI streaming test for fast tip-tilt
 
-**Date:** 2026-07-08
+**Date:** 2026-07-08 (rev. 3: USB-bandwidth sweep, stall fix, high-speed-mode test)
 **Camera:** ZWO ASI294MM Pro (mono, 8288×5644, 12-bit ADC), SDK 1.20.2
 **Server:** `zwoserver` on Raspberry Pi 4 (USB3 to camera), gigabit Ethernet
 **Client:** Raspberry Pi (`zwo-bootsrv`), same gigabit LAN, RTT 0.32 ms
@@ -21,7 +21,10 @@ by the server's sequence counter, so drops are counted exactly.
 
 **Yes at bin 2: a window up to ~200×140 (binned pixels) streams at
 192–194 Hz with zero dropped frames.** Bin 1 tops out at ~105 Hz even
-for an 80×56 window. The limit is camera/USB readout, not the network.
+for an 80×56 window (~+25% with high-speed mode, still well short of
+200 Hz). The limit is camera/USB readout, not the network — and both
+camera-side levers (USB bandwidth, high-speed mode) have been tested
+and do not move the bin 2 ceiling.
 
 ## Measured frame-rate ceilings vs window size
 
@@ -54,16 +57,24 @@ exposure, measured client-side over 20 s (~3900 frames):
 | mean Δt (core) | 5.19 ms → **192.6 Hz** |
 | σ (core) | **0.35 ms** |
 | p95 / p99 / max (core) | 5.5 / 5.6 / 6.3 ms |
-| stalls | **~366 ms, 2–5 per 20 s** (~0.1% of frames) |
+| stalls | **~65 ms, one per 3–10 s** (was ~366 ms before the timeout fix below) |
 
 The core distribution is tight — 0.35 ms rms is small against a 5 ms
-frame period. However, the camera/USB/SDK side occasionally stalls for
-almost exactly 366 ms (a few times per minute; reproduced with all
-instrumentation local to the client, so it is not a network artifact;
-no frames are lost — delivery just pauses). A tip-tilt loop must
-tolerate these ~0.4 s gaps, and they will appear in PSDs as gaps or
-must be masked. Origin not yet identified (SDK-internal; possibly its
-exposure-control thread) — a follow-up item.
+frame period. Frame delivery does stall a few times per minute
+(~0.1–0.3% of frames; no frames are lost, delivery just pauses).
+
+**Stall root cause found and mitigated.** The stall duration always
+equalled the server's `ASIGetVideoData` timeout (350 ms + exposure):
+the SDK's internal circular buffer occasionally misses a wakeup and
+sleeps the *full* timeout even though the frame is already available
+(a lost-wakeup bug in `CirBuf::ReadBuff`, consistent with the gdb
+thread traces). Shrinking the server's timeout floor from 350 ms to
+50 ms cut the stalls from **~366 ms to ~65 ms** with no change in
+rate, jitter, or drops anywhere in the sweep. At 193 Hz a stall now
+costs ~12 frames instead of ~70. The stall *frequency* (one per
+3–10 s) is SDK-internal and unchanged — PSDs still need these short
+gaps masked, and the timeout can be tuned lower if 65 ms is still too
+long.
 
 ## What sets the limits
 
@@ -80,17 +91,55 @@ exposure-control thread) — a follow-up item.
   identical frame rates (the USB link appears to always carry 16-bit
   pixels). 16-bit is fine for centroiding if wanted.
 
-## Headroom / next steps
+## USB bandwidth (`ASI_BANDWIDTHOVERLOAD`) — tested, verdict negative for small ROIs
 
-- **`ASI_BANDWIDTHOVERLOAD` (USB bandwidth %, SDK default 40) is the
-  untested lever.** Raising it should shrink the per-row readout cost
-  and the 5.15 ms floor — likely the path to 200+ Hz at bin 1, and
-  >200 Hz at bin 2. Requires a small server addition (not yet exposed);
-  the benchmark is ready to sweep it.
-- `ASI_HIGH_SPEED_MODE` (10-bit ADC) is a second untested lever, at
-  some cost in bit depth.
+The setting is now exposed as the server's `usb` command
+(`zwo_benchmark --usb N`, 40–100). Sweep at 40 / 60 / 80 / 100 across
+bins 1–2, 8/16-bit, 2–10% windows:
+
+- **No effect on any small-ROI ceiling.** 86.4 / 55.6 / 35.0 Hz (bin 1)
+  and 194 / 193 / 135 Hz (bin 2) are identical to 0.1% at every
+  bandwidth value. The small-window ceilings — including the 5.15 ms
+  bin-2 floor — are **sensor readout timing, not USB transfer**, so
+  bandwidth cannot buy 200 Hz at bin 1.
+- **Large USB-limited frames do speed up**: bin 4 full-frame 16-bit
+  went from 6.8 fps (39 MB/s) at usb=40 to ~10.8 fps (63 MB/s) at
+  usb=100. Useful for full-detector acquisition, irrelevant to the
+  tip-tilt window.
+- Stall frequency and core jitter at the 193 Hz operating point are
+  unchanged by the setting.
+
+## High-speed mode (`ASI_HIGH_SPEED_MODE`, 10-bit ADC) — tested
+
+Exposed as the server's `highspeed` command
+(`zwo_benchmark --highspeed 0/1`). On/off comparison over the same
+matrix:
+
+| config | HSM off | HSM on | change |
+|---|---|---|---|
+| bin 1, 160×112  | 86.4 Hz | 108.2 Hz | **+25%** |
+| bin 1, 408×282  | 55.6 Hz | 69.7 Hz  | **+25%** |
+| bin 1, 824×564  | 35.0 Hz | 43.9 Hz  | **+25%** |
+| bin 2, 80×56    | 194 Hz  | 194 Hz   | none |
+| bin 2, 200×140  | 193 Hz  | 193 Hz   | none |
+| bin 2, 408×282  | 135 Hz  | 135 Hz   | none |
+| bin 4, full     | 13.4 Hz | 13.1 Hz  | none |
+
+- **Bin 1 readout gets uniformly 25% faster** (row time 38 → 30 µs) —
+  but even the smallest window only reaches ~108 Hz, still far from
+  200 Hz, and the ADC drops to 10 bits.
+- **Bin 2 — the tip-tilt operating point — is completely unaffected**,
+  as are bins 4 and both bit depths. The 5.15 ms bin-2 floor stands.
+
+## Remaining headroom
+
+- Both camera-side levers are now exhausted: neither USB bandwidth nor
+  high-speed mode moves the bin-2 floor. **~193 Hz at bin 2 with a
+  ≤200×140 window is the ceiling for this camera + SDK**, and it meets
+  the 200 Hz goal to within 3.5%.
 - The per-frame Δt series (benchmark `--verbose`) gives the timing
   data needed for PSD work directly.
+- The stall-recovery timeout (now 50 ms) can be tuned lower if needed.
 
 ## Server fixes made during this test (already deployed)
 
@@ -106,7 +155,11 @@ on the Raspberry Pi — relevant to anyone reproducing this:
    server segfaulted (confirmed by gdb). Benign on the old x86 host,
    fatal on the Pi. Fixed with proper synchronization and validated
    with 4 consecutive full sweeps (396 configs) with zero crashes.
-4. `Restart=on-failure` added to the systemd unit.
+4. **`usb` and `highspeed` commands added** (`ASI_BANDWIDTHOVERLOAD`
+   40–100, `ASI_HIGH_SPEED_MODE` 0/1).
+5. **`ASIGetVideoData` timeout floor 350 ms → 50 ms**: cuts the
+   SDK lost-wakeup stalls from ~366 ms to ~65 ms.
+6. `Restart=on-failure` added to the systemd unit.
 
 ## Reproducing
 

--- a/docs/ASI294MM-P_200Hz_ROI_report.md
+++ b/docs/ASI294MM-P_200Hz_ROI_report.md
@@ -162,6 +162,35 @@ matrix:
   data needed for PSD work directly.
 - The stall-recovery timeout (now 50 ms) can be tuned lower if needed.
 
+## Cross-camera timestamp validation — to do
+
+The 59 µs jitter above is single-camera *precision*. Using the two
+guiders together for ground-layer PSDs requires their timestamps to be
+mutually *aligned*, which the host-side stamp does not by itself
+guarantee (unknown mode-dependent readout+USB offset; host-clock
+alignment between the two Pis). The literature is unanimous that
+NTP host timestamps cannot be trusted at the ms level without an
+independent optical check — see the plan and precedent (incl.
+proto-Lightspeed on Magellan Clay, ≤30 µs) in
+[two-camera-time-sync-verification.md](two-camera-time-sync-verification.md).
+Open questions to close before trusting cross-camera correlation:
+
+1. Relative timestamp accuracy of the ASI294MM Pro when stamped
+   server-side at USB delivery vs a hardware trigger — no published
+   number exists for this chip.
+2. Rolling-shutter row-dependent exposure offset across the small ROI
+   at 5 ms: fixed per-ROI constant or a row-by-row effect?
+3. Does PTP (vs NTP) between the two Pis actually deliver sub-ms
+   alignment in the field, and validated how? (Pi 4 = software PTP
+   only; CM4/Pi 5 have hardware timestamping.)
+4. Is relative alignment sufficient for the science, or is absolute
+   UTC also required?
+
+Recommended validator: a single GPS-PPS-driven LED imaged
+simultaneously by both cameras, phase-folded on the 1 s edge — cheap,
+measures relative alignment directly, and validates the clock
+discipline end-to-end. Full procedure in the companion doc.
+
 ## Server fixes made during this test (already deployed)
 
 Running at these rates exposed and fixed several issues in `zwoserver`

--- a/docs/camera-time-sync-verification.md
+++ b/docs/camera-time-sync-verification.md
@@ -1,10 +1,12 @@
-# Verifying frame-timestamp synchronization between two ZWO guiders
+# Verifying frame-timestamp synchronization across ZWO guiders
 
 **Date:** 2026-07-09
-**Purpose:** Validate that two ASI294MM Pro guiders (separate Raspberry
-Pi hosts) have frame timestamps aligned to ≲1 ms, so their small-ROI
-193 Hz streams can be cross-correlated for fast tip-tilt / ground-layer
-seeing. Companion to
+**Purpose:** Validate that independently-hosted ASI294MM Pro guiders
+(one Raspberry Pi each) have frame timestamps aligned to ≲1 ms, so
+their small-ROI 193 Hz streams can be cross-correlated for fast
+tip-tilt / ground-layer seeing. Written for the current two-guider
+setup; the method scales to N cameras (e.g. a third on Clay's AUX2).
+Companion to
 [ASI294MM-P_200Hz_ROI_report.md](ASI294MM-P_200Hz_ROI_report.md).
 
 ## Why host timestamps alone are not enough

--- a/docs/camera-time-sync-verification.md
+++ b/docs/camera-time-sync-verification.md
@@ -155,13 +155,37 @@ line; ~10 lines.)*
 2. Rolling-shutter row-dependent exposure offset across the small ROI
    at 5 ms: fixed per-ROI constant, or a row-by-row effect that
    matters for correlation?
-3. Does PTP (vs NTP) between the two Pis actually deliver sub-ms host
+3. Does the chosen clock discipline actually deliver sub-ms host
    alignment in the field? The shared PPS-LED flash is the independent
-   validator. (Note: Pi 4 does software PTP timestamping only; CM4/Pi5
-   have hardware PTP [Geerling 2022].)
+   validator. Preferred discipline is per-host GPS, not PTP — see the
+   clock-architecture section (Pi 4B has no hardware PTP timestamping).
 4. Is relative alignment sufficient for the science, or is absolute
    UTC also needed? The shared LED gives relative directly; absolute
    needs the GPS UTC reference.
+
+## Host clock architecture — per-host GPS beats PTP here
+
+Preferred design: **give each guider Pi its own GPS+PPS discipline**
+(one u-blox NEO-M8T GNSS Timing HAT per host, ~$50, + gpsd + chrony:
+PPS on a GPIO via `dtoverlay=pps-gpio`, NMEA as the coarse anchor).
+This locks each Pi's `CLOCK_REALTIME` — the exact clock zwoserver
+stamps read — to GPS/UTC at ~1 µs. Two (or three) independently
+GPS-locked Stratum-1 clocks are then mutually aligned to ~µs **with no
+PTP or NTP between the hosts at all**, which is cleaner than a
+grandmaster/client link and scales identically to the AUX2 camera.
+The same HAT's PPS also drives the flash-test LED, so one part serves
+both roles.
+
+Why not PTP-between-hosts: the **Raspberry Pi 4 Model B NIC
+(BCM54213PE) has no hardware timestamping**, so a Pi 4 can only run
+`ptp4l` in software-timestamping mode (tens of µs, jittery) — worse
+than per-host GPS. Hardware PTP grandmaster capability (a disciplinable
+PHC with a PPS-sync pin) exists only on the **CM4** (BCM54210PE) and
+**Pi 5** [Geerling 2022; jclark rpi-cm4-ptp-guide]. Confirm each host
+with `ethtool -T eth0` (look for `hardware-transmit`/`hardware-receive`)
+and `cat /proc/device-tree/model`. Only if the hosts are CM4/Pi 5 is
+hardware PTP worth considering over per-host GPS — and even then, with
+per-host GPS the cameras are already aligned, so PTP buys little.
 
 ## Relation to other work
 
@@ -180,3 +204,5 @@ line; ~10 lines.)*
   (arXiv:2601.16268)
 - Basden et al. 2016 — CANARY/DRAGON WFS sync (arXiv:1603.07527)
 - Kulcsár et al. 2018, SPIE 10703 — WFS camera latency measurement
+- Geerling 2022 — PTP hardware timestamping on the Pi CM4 (jeffgeerling.com)
+- jclark, rpi-cm4-ptp-guide — CM4/CM5 hardware PTP + PPS-disciplined PHC

--- a/docs/camera-time-sync-verification.md
+++ b/docs/camera-time-sync-verification.md
@@ -67,8 +67,21 @@ validates the host-clock discipline (NTP vs PTP) end-to-end.
 
 ### Hardware
 
-- **GPS receiver with 1 PPS output** (e.g. u-blox NEO-M8/M9 breakout,
-  ~$20; or a GPS PCIe/HAT if precise absolute UTC is wanted later).
+**Any cheap GPS module with a PPS pin is sufficient.** The PPS edge of
+even a bargain u-blox receiver is accurate to tens of ns against UTC —
+~10⁵× below our 1 ms goal — so the GPS is never the limiting factor;
+LED rise time and the camera are. Do **not** pay for a timing-grade
+receiver for *this* test (that class matters only for host NTP/PTP
+discipline, a separate purchase — see below). Cost-effective options
+with a broken-out PPS pin (approx. prices, verify at retailer):
+
+| module | chipset | PPS | ~price | notes |
+|---|---|---|---|---|
+| **GT-U7** | u-blox NEO-6M | yes | ~$10 | what the Stamp-of-Approval flasher uses; proven for this exact job |
+| **VK2828U7G5LF** | u-blox G7020 | yes | ~$12 | tiny, ceramic antenna, UART+PPS |
+| BN-220 / BN-880 | u-blox M8 | yes | ~$15–20 | ubiquitous drone module, PPS on a pad |
+| ATGM336H | AT6668 (non-ublox) | yes | ~$6 | multi-GNSS, cheapest; PPS output |
+
 - **LED + driver** switched by the PPS edge. A single logic gate /
   MOSFET is enough; keep LED rise time « target (a plain LED is
   <1 µs, far below our 1 ms goal). Optionally stretch the pulse to a
@@ -76,6 +89,21 @@ validates the host-clock discipline (NTP vs PTP) end-to-end.
 - LED positioned in both cameras' fields (diffuser / shared fiber /
   simply both looking at the same lab wall spot). No optical precision
   needed — only that both see the same on/off transition.
+
+**Strongly consider not building this from scratch:** the occultation
+community's **Stamp of Approval** (ChasinSpin, MIT-licensed open
+hardware) is *exactly* this device — GT-U7 GPS + constant-current LED
+driver, hardware-gated so the GPS→LED delay is ~53 ns, purpose-built
+to test camera frame-timestamp accuracy (validated to ≤0.1 ms at
+30 fps). Either buy/build it as-is, or lift its LED-driver + PPS-gating
+schematic. https://github.com/ChasinSpin/StampOfApproval
+
+*Separate concern — host clock discipline:* for continuously
+disciplining the two Pi clocks (NTP/PTP, the ansible task), a
+timing-grade receiver like the **u-blox NEO-M8T GNSS Timing HAT**
+(~$50) is the right class — it has the single-satellite timing mode
+the navigation modules above lack. That is not needed for the flash
+test but is the module to standardize on for the sync rollout.
 
 ### Capture
 

--- a/docs/plans/zwo-frame-timestamp.md
+++ b/docs/plans/zwo-frame-timestamp.md
@@ -1,0 +1,136 @@
+# ZWO Server: per-frame timestamps with ns precision — Plan
+
+## Context
+
+PSD / fast tip-tilt work ([docs/ASI294MM-P_200Hz_ROI_report.md](../ASI294MM-P_200Hz_ROI_report.md))
+needs per-frame timing. Today clients can only timestamp frames on
+arrival, which folds network and protocol jitter into the timing data
+and mis-times the ~65 ms SDK lost-wakeup stall frames. A server-side
+timestamp taken the moment `ASIGetVideoData` returns removes every
+client-side jitter source and lets two guiders be cross-correlated on
+absolute time.
+
+## Protocol change (backwards compatible)
+
+`next` response gains a 4th header field:
+
+```
+old:  "seq temp power\n"        + pixel data
+new:  "seq temp power ts_ns\n"  + pixel data
+```
+
+`ts_ns` = `CLOCK_REALTIME` in integer nanoseconds at the instant the
+server received the frame from the SDK.
+
+**Compatibility audit (all in-repo `next` consumers):**
+
+| client | parsing | verdict |
+|---|---|---|
+| gcam ([zwotcp.c:409](../../src/gcam/zwotcp.c#L409)) | `sscanf("%u %lf %d")`, checks `n == 3` | prefix parse; extra token ignored, `n` stays 3 — **unaffected, no change needed** |
+| ZWOFinder (ZWO.m) | does not use `next` (still-image mode) | unaffected |
+| src/py/zwoclient.py | does not use `next` (temp/fan only) | unaffected |
+| src/benchmark | ours | updated to parse the new field |
+| src/py/zwo_emulator.py | ours | updated to emit the new field |
+
+Bump `P_VERSION` 1.0.4 → 1.0.5 so clients can feature-detect via the
+existing `version` command.
+
+## Timestamp semantics (document in code and README)
+
+- **Clock**: `CLOCK_REALTIME`, ns. Chosen over MONOTONIC so the two
+  guiders (separate hosts, NTP-synced — `zwo.service` orders after
+  `ntpdate`) can be cross-correlated on absolute time. Caveat: not
+  guaranteed monotonic under NTP steps.
+- **Epoch marked**: end of USB delivery of the frame (when
+  `ASIGetVideoData` returns), not exposure start. The offset from
+  exposure start (readout + USB transfer) is constant per
+  configuration, so PSD shapes are unaffected.
+- **Stall caveat**: for the ~0.1% lost-wakeup stall frames the frame
+  was exposed on schedule but delivered late — its timestamp is late
+  by the stall duration (~65 ms). These frames are identifiable as
+  Δts spikes and should be masked, exactly as arrival-time analysis
+  already requires.
+
+## Implementation
+
+### Server — src/server/zwoserver.c
+
+1. `static unsigned long long video_ts[2];` next to `video_data1/2`
+   (`[0]` ↔ `video_data1`, `[1]` ↔ `video_data2`), plus a small
+   `time_ns()` helper using `clock_gettime(CLOCK_REALTIME,...)`.
+2. `run_video`: on `ASI_SUCCESS`, store `time_ns()` into the slot
+   matching the buffer just written, **before** the existing
+   `__sync_synchronize()` that precedes `video_seq++` — the current
+   release/acquire pair then covers the timestamp exactly like the
+   pixel data (no new synchronization needed).
+3. `next` handler: pick the slot with the same parity expression used
+   for the data pointer and append `%llu` to the answer.
+4. `P_VERSION` → "1.0.5" in zwo.h.
+
+### Emulator — src/py/zwo_emulator.py
+
+5. Append `time.time_ns()` to the `next` response line.
+
+### Benchmark — src/benchmark/zwo_benchmark.c
+
+6. `next_frame()` parses the optional 4th field (`ts_ns = 0` when
+   absent → works against old servers).
+7. `--verbose` prints both the client-side `dt` and the server-side
+   `dts` per frame — separating camera timing from protocol/network
+   jitter is precisely the measurement the PSD work needs.
+
+### Not in scope (note as future)
+
+Timestamping the single-exposure path (`ASIGetDataAfterExp`) and a
+FITS keyword in `write` — same pattern, add when needed.
+
+## Edge cases
+
+- Answer-line length grows ~20 chars: server composes into
+  `buf[256]` in `run_connection`, clients read into ≥128-byte
+  buffers; `"4294967295 -12.3 100 1783512345678901234"` ≈ 42 chars —
+  fine everywhere.
+- `%llu` on aarch64/x86-64: fine; no 32-bit targets remain.
+- Old benchmark binaries against the new server: prefix parse, works.
+- New benchmark against an old server: `sscanf` yields 3 fields,
+  `ts_ns` stays 0, verbose prints `dts=0` — degrade gracefully.
+
+## Verification
+
+1. **Emulator dry-run**: two configs; assert `ts_ns` strictly
+   increasing and `Δts ≈ 1/fps`.
+2. **Compat proof**: run the *pre-change* benchmark binary (kept on
+   zwo-bootsrv) against the new server — must parse and stream with
+   zero drops. gcam needs no rebuild (audit above); optionally smoke
+   test it.
+3. **Real camera**: at the 193 Hz operating point (bin 2, 200×140,
+   5 ms), compare server-side `Δts` scatter vs client-side `Δt`
+   scatter — expect σ(Δts) < σ(Δt) = 0.35 ms, confirming the
+   protocol-jitter removal. Stall frames must show matching ~65 ms
+   spikes in both.
+4. **Regression**: full default sweep (42 configs) clean, zero
+   crashes — no state-machine changes are made, so risk is low.
+5. Update [src/benchmark/README.md](../../src/benchmark/README.md)
+   and the tip-tilt report with the server-timestamp jitter numbers.
+
+## Critical files
+
+- **Modify**: [src/server/zwoserver.c](../../src/server/zwoserver.c),
+  [src/server/zwo.h](../../src/server/zwo.h) (version),
+  [src/benchmark/zwo_benchmark.c](../../src/benchmark/zwo_benchmark.c),
+  [src/py/zwo_emulator.py](../../src/py/zwo_emulator.py)
+- **Audited, unchanged**: [src/gcam/zwotcp.c](../../src/gcam/zwotcp.c),
+  src/finder/ZWOFinder/ZWO.m, src/py/zwoclient.py
+
+## Execution order
+
+1. **First**: branch `plan/zwo-frame-timestamp` off
+   `plan/zwo-benchmark` (this builds on the barrier/buffer work not
+   yet on `main`), commit this plan standalone
+   (`plan: add per-frame ns timestamps to zwo server`).
+2. `step-01-server`: zwoserver.c + zwo.h + emulator; emulator
+   verification.
+3. `step-02-benchmark`: client parsing + verbose `dts`; deploy to
+   10.8.80.225 and run verification 2–4 (build/restart on the camera
+   host per the standing authorization).
+4. Docs updates (README + report rev. 4).

--- a/docs/two-camera-time-sync-verification.md
+++ b/docs/two-camera-time-sync-verification.md
@@ -1,0 +1,152 @@
+# Verifying frame-timestamp synchronization between two ZWO guiders
+
+**Date:** 2026-07-09
+**Purpose:** Validate that two ASI294MM Pro guiders (separate Raspberry
+Pi hosts) have frame timestamps aligned to ≲1 ms, so their small-ROI
+193 Hz streams can be cross-correlated for fast tip-tilt / ground-layer
+seeing. Companion to
+[ASI294MM-P_200Hz_ROI_report.md](ASI294MM-P_200Hz_ROI_report.md).
+
+## Why host timestamps alone are not enough
+
+Our server stamps each frame with `CLOCK_REALTIME` at USB delivery
+(zwoserver ≥ 1.0.5). That gives excellent *precision* — 59 µs rms
+frame-interval jitter, measured — but says nothing about two things
+that a cross-camera measurement depends on:
+
+1. **Absolute offset.** The stamp is taken *after* readout + USB
+   transfer, an unknown, mode-dependent delay from the true photon
+   epoch. The AO-camera literature is explicit that this latency is
+   **not a fixed constant** — it varies with readout mode, ROI, and
+   trigger [Kulcsár et al. 2018 SPIE 10703]. So the offset can differ
+   between two cameras even if both are configured "the same."
+2. **Host-clock alignment.** The two Pis' clocks must agree.
+   NTP-disciplined PC clocks have been measured wrong by **tens to
+   hundreds of ms** in real astronomy software (802 ms, 79 ± 17 ms,
+   up to 1 s) [Barry et al. 2015 PASA 32 e014]. On our own camera host
+   we already found `NTPSynchronized=no` with a free-running clock.
+
+The established fix in every relevant community — occultation timing
+(IOTA), high-speed photometry, adaptive optics — is an **independent
+optical check with a GPS-referenced light source**, never trusting the
+host clock at the ms level without it [Barry 2015; Dhillon et al. 2021
+MNRAS, HiPERCAM; Layden, Burdge et al. 2026 PASP, proto-Lightspeed].
+
+## Precedent (what the literature achieves)
+
+| System | Method | Accuracy | Source |
+|---|---|---|---|
+| proto-Lightspeed (**Magellan Clay**, our site) | GPS-PPS hardware trigger + TTL end-of-readout time-tag; validated on-sky vs Crab pulsar | **≤30 µs absolute** | Layden/Burdge 2026 PASP (arXiv:2601.16268) |
+| HiPERCAM | GPS PPS-driven LED on focal-plane mask, phase-folded on 1 s | **~100 µs** | Dhillon 2021 (arXiv:2107.10124) |
+| proto-Lightspeed lab | GPS-PPS-pulsed LED, mid-exposure recovery | **<50 µs** (LED-rise-limited) | arXiv:2601.16268 |
+| SEXTA (occultation) | 500-LED sweep, 1 lit/2 ms from UTC second | **2 ms** frames; device <0.2 ms to UTC | Barry 2015 (arXiv:1503.05705) |
+
+Key architectural lesson from multi-camera AO (CANARY on-sky, DRAGON
+lab): align **exposure mid-points**, not data-arrival times — two
+cameras with different readout times expose at different epochs even
+with identical timestamps; both systems switched from aligning
+pixel-arrival to a shared trigger for this reason [Basden et al.,
+arXiv:1603.07527].
+
+**Caveat on transfer:** those sub-100 µs numbers are what *dedicated
+GPS-trigger hardware* achieves. Our server-side-over-USB approach will
+be worse; how much worse for the ASI294MM Pro at 193 Hz is
+uncharacterized in the literature and is exactly what this test
+measures.
+
+## Recommended test — shared GPS-PPS LED, phase-folded
+
+A single GPS-PPS-driven LED placed so **both cameras image it
+simultaneously**. This is the cheapest recipe from the literature and
+uniquely fits our need: because both cameras see the *same physical
+flash*, it measures their **relative** alignment directly — which is
+what cross-correlation needs (relative, not absolute UTC) — and it
+validates the host-clock discipline (NTP vs PTP) end-to-end.
+
+### Hardware
+
+- **GPS receiver with 1 PPS output** (e.g. u-blox NEO-M8/M9 breakout,
+  ~$20; or a GPS PCIe/HAT if precise absolute UTC is wanted later).
+- **LED + driver** switched by the PPS edge. A single logic gate /
+  MOSFET is enough; keep LED rise time « target (a plain LED is
+  <1 µs, far below our 1 ms goal). Optionally stretch the pulse to a
+  few ms so it lands cleanly inside one 5 ms frame.
+- LED positioned in both cameras' fields (diffuser / shared fiber /
+  simply both looking at the same lab wall spot). No optical precision
+  needed — only that both see the same on/off transition.
+
+### Capture
+
+Use the existing benchmark's timestamp path — no new capture code:
+
+```
+# on each Pi host, simultaneously, small ROI around the LED:
+zwo_benchmark --host <cam> --bins 2 --bits 8 --rois 5 \
+    --exptimes 0.005 --duration 120 -v 2> cam<N>_dt.log
+```
+
+`--verbose` already logs per-frame `ts=<ns>` (the server
+CLOCK_REALTIME stamp) plus the ROI pixels are in the stream. For this
+test add a tiny capture that records, per frame, `(ts_ns, mean_ROI_flux)`
+— the LED shows up as a flux step. *(If preferred I can add a
+`--flux-log` option that appends mean-ROI intensity to the verbose
+line; ~10 lines.)*
+
+### Analysis
+
+1. In each camera's series, find the frame where LED flux crosses
+   its half-max — that frame's `ts_ns` is the camera's measured "LED
+   lit" time.
+2. **Relative alignment** = difference between the two cameras'
+   crossing timestamps, per PPS second. Fold over many seconds (120 s
+   → ~120 flashes) → mean gives the fixed inter-camera offset,
+   scatter gives the alignment jitter. Target: |mean| and σ both
+   ≲ 1 ms.
+3. **Absolute check** (optional, needs the GPS UTC): each camera's
+   crossing `ts_ns mod 1 s` vs 0 → the host-clock-to-UTC error,
+   directly exposing an NTP offset like the ones the papers document.
+4. Sub-frame interpolation: with a ~ms LED pulse and 5 ms frames,
+   interpolate the flux rise across 1–2 frames to beat the 5 ms
+   sampling — this is the phase-folding step HiPERCAM/proto-Lightspeed
+   use to reach µs from coarse frames.
+
+### Pass criteria
+
+- Inter-camera offset stable and < 1 ms after whatever clock
+  discipline is deployed (NTP now; PTP later — see below).
+- Offset **repeatable** across ROI/exposure changes, or if not,
+  characterized as a lookup (the mode-dependent-latency pitfall).
+
+## Open questions this test answers (added to the report)
+
+1. Relative timestamp accuracy of the ASI294MM Pro server-timestamped
+   at USB delivery vs a hardware trigger — the number no published
+   source provides for this chip.
+2. Rolling-shutter row-dependent exposure offset across the small ROI
+   at 5 ms: fixed per-ROI constant, or a row-by-row effect that
+   matters for correlation?
+3. Does PTP (vs NTP) between the two Pis actually deliver sub-ms host
+   alignment in the field? The shared PPS-LED flash is the independent
+   validator. (Note: Pi 4 does software PTP timestamping only; CM4/Pi5
+   have hardware PTP [Geerling 2022].)
+4. Is relative alignment sufficient for the science, or is absolute
+   UTC also needed? The shared LED gives relative directly; absolute
+   needs the GPS UTC reference.
+
+## Relation to other work
+
+- Continuous host time sync (chrony/PTP) is a prerequisite and is
+  tracked separately for the ansible rollout (see project memory).
+- If sub-ms proves impossible over USB, the fallback is the
+  proto-Lightspeed architecture (GPS PCIe/HAT with PPS trigger + TTL
+  end-of-readout tag) — same telescope, proven ≤30 µs — at the cost of
+  added hardware and losing the ZWO's simple USB streaming.
+
+## Primary sources
+
+- Barry et al. 2015, PASA 32 e014 — SEXTA (arXiv:1503.05705)
+- Dhillon et al. 2021, MNRAS — HiPERCAM timing (arXiv:2107.10124)
+- Layden, Burdge et al. 2026, PASP — proto-Lightspeed, Magellan Clay
+  (arXiv:2601.16268)
+- Basden et al. 2016 — CANARY/DRAGON WFS sync (arXiv:1603.07527)
+- Kulcsár et al. 2018, SPIE 10703 — WFS camera latency measurement

--- a/etc/systemd/system/zwo.service
+++ b/etc/systemd/system/zwo.service
@@ -14,6 +14,8 @@ Wants=network-online.target
 Type=simple
 User=root
 ExecStart=/usr/local/bin/zwoserver
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=default.target

--- a/src/benchmark/README.md
+++ b/src/benchmark/README.md
@@ -37,7 +37,9 @@ zwo_benchmark [options]
   --usb N                 ASI_BANDWIDTHOVERLOAD 40..100 (optional)
   --highspeed N           ASI_HIGH_SPEED_MODE 0/1, 10-bit ADC (optional)
   --csv PATH              also write results as CSV (optional)
-  -v, --verbose           per-frame stderr logging
+  -v, --verbose           per-frame stderr logging (dt = client arrival
+                          interval, dts = server-side frame interval
+                          from the per-frame ns timestamps, v1.0.5+)
   -h, --help
 ```
 
@@ -214,6 +216,14 @@ Findings (after the 2026-07-08 server fixes, see below):
   `ASI_HIGH_SPEED_MODE`), and the `ASIGetVideoData` timeout floor
   lowered 350 ms -> 50 ms (SDK lost-wakeup stalls shrink from ~366 ms
   to ~65 ms).
+- **Per-frame ns timestamps** (server v1.0.5): `next` answers
+  `"seq temp power ts_ns"` — CLOCK_REALTIME at the instant the SDK
+  delivered the frame (switch `TS_CLOCK` to CLOCK_TAI on PTP hosts).
+  Backwards compatible: gcam's prefix `sscanf` ignores the new field
+  (audited; ZWOFinder and zwoclient.py don't use `next`). Measured at
+  193 Hz: true camera delivery jitter is **0.059 ms rms** vs 0.524 ms
+  seen client-side — the timestamps remove protocol/network jitter
+  from PSD data entirely.
 - Validated: 4 consecutive full 96-config sweeps + tiny-ROI set
   (396 configs, ~100 stop/setup/start transitions) with zero failures
   and zero crashes under gdb.

--- a/src/benchmark/README.md
+++ b/src/benchmark/README.md
@@ -34,6 +34,8 @@ zwo_benchmark [options]
   --next-timeout SEC      timeout passed to 'next' (default: 2.0)
   --gain N                (optional)
   --offset N              (optional)
+  --usb N                 ASI_BANDWIDTHOVERLOAD 40..100 (optional)
+  --highspeed N           ASI_HIGH_SPEED_MODE 0/1, 10-bit ADC (optional)
   --csv PATH              also write results as CSV (optional)
   -v, --verbose           per-frame stderr logging
   -h, --help
@@ -169,10 +171,26 @@ Findings (after the 2026-07-08 server fixes, see below):
 - **200 Hz verdict: reachable at bin 2** with windows up to ~200x140
   binned pixels: 192-194 fps (96% efficiency) at 5 ms exposure, zero
   drops. At bin 1 even 80x56 only reaches ~105 fps.
-- **Untested lever**: `ASI_BANDWIDTHOVERLOAD` (USB bandwidth %, SDK
-  default 40) is not exposed by zwoserver; raising it should shrink
-  the per-row readout cost and lift the camera-limited ceilings
-  above (including the ~5.15 ms floor).
+- **`ASI_BANDWIDTHOVERLOAD` tested — no effect on small-ROI
+  ceilings.** Now exposed as the server's `usb` command
+  (`--usb N`, 40–100). Swept 40/60/80/100: every small-window ceiling
+  (86.4/55.6/35.0 Hz bin 1; 194/193/135 Hz bin 2, incl. the 5.15 ms
+  floor) is identical to 0.1% at all values — those are sensor readout
+  timing, not USB transfer. Only USB-limited large frames speed up
+  (bin 4 full-frame 16-bit: 6.8 fps @40 → ~10.8 fps @100).
+- **`ASI_HIGH_SPEED_MODE` tested — bin 1 only, +25%.** Exposed as the
+  server's `highspeed` command (`--highspeed 0/1`). Bin 1 readout gets
+  uniformly 25% faster (86.4→108.2, 55.6→69.7, 35.0→43.9 Hz; row time
+  38→30 µs) at the cost of a 10-bit ADC — still far below 200 Hz. Bin 2
+  (incl. the 5.15 ms floor), bin 4, and both bit depths are unaffected.
+  With both camera levers exhausted, ~193 Hz at bin 2 ≤200x140 is the
+  ceiling for this camera + SDK.
+- **~366 ms delivery stalls explained and mitigated**: a few times per
+  minute the SDK's `CirBuf::ReadBuff` misses a wakeup and sleeps the
+  full `ASIGetVideoData` timeout even though the frame is ready (stall
+  length exactly tracked the timeout). Lowering the server's timeout
+  floor from 350 ms to 50 ms cut stalls to ~65 ms with no change in
+  rate, jitter (0.35 ms rms at 193 Hz), or drops.
 
 ### Server fixes this benchmark motivated (zwoserver.c, 2026-07-08)
 
@@ -192,11 +210,16 @@ Findings (after the 2026-07-08 server fixes, see below):
 - Video thread lifetime serialized across stop/start, SDK buffers
   padded (`SDK_BUF_PAD`), 350 ms settle after `ASIStopVideoCapture`,
   and `Restart=on-failure` in `zwo.service`.
+- `usb` and `highspeed` commands added (`ASI_BANDWIDTHOVERLOAD`,
+  `ASI_HIGH_SPEED_MODE`), and the `ASIGetVideoData` timeout floor
+  lowered 350 ms -> 50 ms (SDK lost-wakeup stalls shrink from ~366 ms
+  to ~65 ms).
 - Validated: 4 consecutive full 96-config sweeps + tiny-ROI set
   (396 configs, ~100 stop/setup/start transitions) with zero failures
   and zero crashes under gdb.
 
 ## TODO
 
-Sweep `ASI_BANDWIDTHOVERLOAD` once `zwoserver.c` exposes a command to
-set it (currently only exposure/gain/offset/cooler are wired).
+Camera-side levers (`ASI_BANDWIDTHOVERLOAD`, `ASI_HIGH_SPEED_MODE`)
+are both tested; no further server-side knobs are known that could
+lift the bin-2 5.15 ms readout floor.

--- a/src/benchmark/README.md
+++ b/src/benchmark/README.md
@@ -1,0 +1,202 @@
+# zwo_benchmark — ZWO server FPS benchmark
+
+Measures client-side frames-per-second of the ZWO camera server
+(`src/server/zwoserver.c`, port 52311) in video-streaming mode
+(`start` → loop `next` → `stop`), sweeping exposure time, binning, and
+pixel bit depth. For each configuration it reports actual FPS vs the
+expected FPS (`1/exptime`), frame drops (gaps in the server's `seq`
+counter), and network throughput.
+
+Plan / design notes: [docs/plans/zwo-benchmark.md](../../docs/plans/zwo-benchmark.md)
+
+## Build
+
+Links against the server's `tcpip`/`utils`/`ptlib` objects (Linux target):
+
+```
+make -C src/server tcpip.o utils.o ptlib.o
+make -C src/benchmark
+```
+
+## Usage
+
+```
+zwo_benchmark [options]
+  --host HOST             (default: localhost)
+  --port PORT             (default: 52311)
+  --exptimes CSV          (default: 0.001,0.005,0.01,0.05,0.1,0.5,1.0)
+  --bins CSV              (default: 1,2,4)
+  --bits CSV              (default: 8,16)
+  --rois CSV              window size as % of full frame, centered
+                          (default: 100; e.g. 10,50,80,100)
+  --duration SEC          measurement window per config (default: 10.0)
+  --warmup SEC            discarded frames before measuring (default: 3.0)
+  --next-timeout SEC      timeout passed to 'next' (default: 2.0)
+  --gain N                (optional)
+  --offset N              (optional)
+  --csv PATH              also write results as CSV (optional)
+  -v, --verbose           per-frame stderr logging
+  -h, --help
+```
+
+Example — full default sweep against a remote server, with CSV output:
+
+```
+./zwo_benchmark --host 10.8.80.225 --csv results.csv
+```
+
+Ctrl-C stops cleanly: the current config's partial row is kept and
+labelled `interrupted`.
+
+## Example results
+
+Full default sweep (42 configs, 10 s each) run 2026-07-08 on
+`zwo-bootsrv` (Raspberry Pi, gigabit Ethernet) against an
+ASI294MM Pro served from 10.8.80.225, with the 2026-07-08 server
+fixes deployed (see below):
+
+```
+ZWO benchmark   host=10.8.80.225:52311   duration=10.0s   warmup=3.0s
+camera: ZWO_ASI294MM_Pro  8288x5644  cooler=1 color=0 bitDepth=12
+
++--------+-----+------+-------+------+------+--------+---------+---------+---------+-------+------+---------+--------+--------------------+
+| exptim | bin | bits | roi%  | W    | H    | frames | elapsed | fps     | expFPS  | eff%  | drop | enodata | MB/s   | note               |
++--------+-----+------+-------+------+------+--------+---------+---------+---------+-------+------+---------+--------+--------------------+
+| 0.0010 |   1 |    8 | 100.0 | 8288 | 5644 |     22 |   10.35 |    2.13 | 1000.00 |   0.2 |   24 |       0 |   99.4 |                    |
+| 0.0050 |   1 |    8 | 100.0 | 8288 | 5644 |     22 |   10.28 |    2.14 |  200.00 |   1.1 |   24 |       0 |  100.1 |                    |
+| 0.0100 |   1 |    8 | 100.0 | 8288 | 5644 |     22 |   10.28 |    2.14 |  100.00 |   2.1 |   24 |       0 |  100.1 |                    |
+| 0.0500 |   1 |    8 | 100.0 | 8288 | 5644 |     22 |   10.26 |    2.14 |   20.00 |  10.7 |   24 |       0 |  100.3 |                    |
+| 0.1000 |   1 |    8 | 100.0 | 8288 | 5644 |     22 |   10.38 |    2.12 |   10.00 |  21.2 |   24 |       0 |   99.2 |                    |
+| 0.5000 |   1 |    8 | 100.0 | 8288 | 5644 |     20 |   10.01 |    2.00 |    2.00 |  99.9 |    0 |       0 |   93.4 |                    |
+| 1.0000 |   1 |    8 | 100.0 | 8288 | 5644 |      8 |   10.32 |    0.78 |    1.00 |  77.5 |    0 |       0 |   36.3 |                    |
+| 0.0010 |   2 |    8 | 100.0 | 4144 | 2822 |     85 |   10.07 |    8.44 | 1000.00 |   0.8 |   78 |       0 |   98.7 |                    |
+| 0.0050 |   2 |    8 | 100.0 | 4144 | 2822 |     85 |   10.04 |    8.47 |  200.00 |   4.2 |   78 |       0 |   99.0 |                    |
+| 0.0100 |   2 |    8 | 100.0 | 4144 | 2822 |     83 |   10.03 |    8.28 |  100.00 |   8.3 |   79 |       0 |   96.8 |                    |
+| 0.0500 |   2 |    8 | 100.0 | 4144 | 2822 |     85 |   10.11 |    8.40 |   20.00 |  42.0 |   79 |       0 |   98.3 |                    |
+| 0.1000 |   2 |    8 | 100.0 | 4144 | 2822 |     93 |   10.06 |    9.24 |   10.00 |  92.4 |    7 |       0 |  108.1 |                    |
+| 0.5000 |   2 |    8 | 100.0 | 4144 | 2822 |     20 |   10.00 |    2.00 |    2.00 | 100.0 |    0 |       0 |   23.4 |                    |
+| 1.0000 |   2 |    8 | 100.0 | 4144 | 2822 |      9 |   10.25 |    0.88 |    1.00 |  87.8 |    0 |       0 |   10.3 |                    |
+| 0.0010 |   4 |    8 | 100.0 | 2072 | 1410 |    150 |   10.04 |   14.95 | 1000.00 |   1.5 |    0 |       0 |   43.7 |                    |
+| 0.0050 |   4 |    8 | 100.0 | 2072 | 1410 |    149 |   10.03 |   14.86 |  200.00 |   7.4 |    0 |       0 |   43.4 |                    |
+| 0.0100 |   4 |    8 | 100.0 | 2072 | 1410 |    150 |   10.05 |   14.93 |  100.00 |  14.9 |    0 |       0 |   43.6 |                    |
+| 0.0500 |   4 |    8 | 100.0 | 2072 | 1410 |    130 |   10.04 |   12.95 |   20.00 |  64.7 |    0 |       0 |   37.8 |                    |
+| 0.1000 |   4 |    8 | 100.0 | 2072 | 1410 |    100 |   10.02 |    9.98 |   10.00 |  99.8 |    0 |       0 |   29.2 |                    |
+| 0.5000 |   4 |    8 | 100.0 | 2072 | 1410 |     20 |   10.00 |    2.00 |    2.00 | 100.0 |    0 |       0 |    5.8 |                    |
+| 1.0000 |   4 |    8 | 100.0 | 2072 | 1410 |      9 |   10.26 |    0.88 |    1.00 |  87.7 |    0 |       0 |    2.6 |                    |
+| 0.0010 |   1 |   16 | 100.0 | 8288 | 5644 |      9 |   10.26 |    0.88 | 1000.00 |   0.1 |   23 |       0 |   82.1 |                    |
+| 0.0050 |   1 |   16 | 100.0 | 8288 | 5644 |      9 |   10.18 |    0.88 |  200.00 |   0.4 |   22 |       0 |   82.7 |                    |
+| 0.0100 |   1 |   16 | 100.0 | 8288 | 5644 |      9 |   10.01 |    0.90 |  100.00 |   0.9 |   22 |       0 |   84.1 |                    |
+| 0.0500 |   1 |   16 | 100.0 | 8288 | 5644 |      9 |   10.17 |    0.89 |   20.00 |   4.4 |   22 |       0 |   82.8 |                    |
+| 0.1000 |   1 |   16 | 100.0 | 8288 | 5644 |      9 |   10.27 |    0.88 |   10.00 |   8.8 |   23 |       0 |   82.0 |                    |
+| 0.5000 |   1 |   16 | 100.0 | 8288 | 5644 |     12 |   10.53 |    1.14 |    2.00 |  57.0 |    9 |       0 |  106.7 |                    |
+| 1.0000 |   1 |   16 | 100.0 | 8288 | 5644 |      8 |   11.01 |    0.73 |    1.00 |  72.6 |    0 |       0 |   68.0 |                    |
+| 0.0010 |   2 |   16 | 100.0 | 4144 | 2822 |     39 |   10.20 |    3.82 | 1000.00 |   0.4 |   82 |       0 |   89.4 |                    |
+| 0.0050 |   2 |   16 | 100.0 | 4144 | 2822 |     36 |   10.18 |    3.54 |  200.00 |   1.8 |   94 |       0 |   82.7 |                    |
+| 0.0100 |   2 |   16 | 100.0 | 4144 | 2822 |     41 |   10.17 |    4.03 |  100.00 |   4.0 |   69 |       0 |   94.3 |                    |
+| 0.0500 |   2 |   16 | 100.0 | 4144 | 2822 |     41 |   10.20 |    4.02 |   20.00 |  20.1 |   72 |       0 |   94.0 |                    |
+| 0.1000 |   2 |   16 | 100.0 | 4144 | 2822 |     43 |   10.21 |    4.21 |   10.00 |  42.1 |   58 |       0 |   98.5 |                    |
+| 0.5000 |   2 |   16 | 100.0 | 4144 | 2822 |     21 |   10.50 |    2.00 |    2.00 | 100.0 |    0 |       0 |   46.8 |                    |
+| 1.0000 |   2 |   16 | 100.0 | 4144 | 2822 |      9 |   10.35 |    0.87 |    1.00 |  87.0 |    0 |       0 |   20.3 |                    |
+| 0.0010 |   4 |   16 | 100.0 | 2072 | 1410 |    115 |   10.09 |   11.40 | 1000.00 |   1.1 |    0 |       0 |   66.6 |                    |
+| 0.0050 |   4 |   16 | 100.0 | 2072 | 1410 |     90 |   10.08 |    8.93 |  200.00 |   4.5 |    0 |       0 |   52.2 |                    |
+| 0.0100 |   4 |   16 | 100.0 | 2072 | 1410 |    116 |   10.01 |   11.59 |  100.00 |  11.6 |    0 |       0 |   67.7 |                    |
+| 0.0500 |   4 |   16 | 100.0 | 2072 | 1410 |    114 |   10.08 |   11.31 |   20.00 |  56.5 |    0 |       0 |   66.1 |                    |
+| 0.1000 |   4 |   16 | 100.0 | 2072 | 1410 |    100 |   10.02 |    9.98 |   10.00 |  99.8 |    0 |       0 |   58.3 |                    |
+| 0.5000 |   4 |   16 | 100.0 | 2072 | 1410 |     20 |   10.01 |    2.00 |    2.00 |  99.9 |    0 |       0 |   11.7 |                    |
+| 1.0000 |   4 |   16 | 100.0 | 2072 | 1410 |      9 |   10.35 |    0.87 |    1.00 |  87.0 |    0 |       0 |    5.1 |                    |
++--------+-----+------+-------+------+------+--------+---------+---------+---------+-------+------+---------+--------+--------------------+
+```
+
+### Reading the numbers
+
+- **Column meanings**: `fps` = frames/elapsed over the measurement
+  window; `expFPS` = 1/exptime; `eff%` = fps/expFPS; `drop` = frames
+  the server produced but the client never saw (gaps in `seq`);
+  `enodata` = `next` calls that timed out; `MB/s` = pixel payload
+  received per second.
+- **Gigabit Ethernet is the bottleneck for large frames**: every fast
+  config plateaus at ~95–108 MB/s (wire speed). That caps bin 1 8-bit
+  at ~2.1 fps (46.8 MB/frame), bin 1 16-bit at ~0.9 fps, and bin 2
+  8-bit at ~8.4 fps regardless of exposure time. Non-zero `drop`
+  counts appear in exactly those network-limited configs: the server's
+  two rotating buffers overwrite frames faster than the client drains
+  them.
+- **Bin 4 is camera-limited**: it tops out at ~15 fps (8-bit) /
+  ~11.5 fps (16-bit) while moving only 40–68 MB/s with zero drops, so
+  the ceiling there is sensor readout / USB bandwidth on the server
+  host, not the network.
+- **~0.87 fps at 1.0 s exposure** across all bins (0.5 s reaches 100%
+  efficiency) suggests a fixed per-frame overhead that only becomes
+  visible at long exposures — unexplained, worth a closer look.
+
+## ROI sweep — can a small window reach 200 Hz?
+
+Motivation: acquire with the full detector, then read a small window
+around the guide star as close to 200 Hz as possible (fast-guiding /
+ground-layer PSD study). Question: is the small-window limit the
+1 Gbps link, or is there per-frame overhead?
+
+Sweep run 2026-07-08, same setup as above (`--rois 10,50,80,100`,
+exposures 0.5–50 ms, bins 1–2, 8/16 bit; full data in
+`results_roi.csv` on zwo-bootsrv), plus a tiny-window run
+(`--rois 1,2,5`). FPS ceilings observed (exposure short enough not to
+matter, 8-bit; 16-bit gives the *same* fps wherever the wire isn't
+saturated):
+
+```
+bin 1:  80x56 -> 105 fps   160x112 -> 86 fps   408x282 -> 56 fps
+        824x564 -> 35 fps  4144x2822 -> 8.8 fps (wire-limited)
+bin 2:  80x56 -> 194 fps   200x140 -> 193 fps  408x282 -> 135 fps
+        2072x1410 -> 32 fps  4144x2822 -> 8.1 fps (wire-limited)
+```
+
+Findings (after the 2026-07-08 server fixes, see below):
+
+- **Small windows never touch the wire** (a 10% bin-1 window moves
+  only 16 MB/s at its 35 fps ceiling); the limit is per-frame
+  overhead, answering the original question: ROI cut-off has real
+  overhead, the 1 Gbps link is only the limit above ~50% window.
+- **The overhead is linear in window height** plus a fixed floor.
+  Bin 1 fits `period ~ 7.4 ms + 38 us/row`; readout (camera/USB side),
+  not network. Bit depth is free below the wire limit — 8 and 16 bit
+  reach identical fps, so the USB side appears to always move 16-bit
+  pixels.
+- **The ~194 fps ceiling is the camera itself** (~5.15 ms minimum
+  frame period at bin 2 small ROI, SDK 1.20.2, default USB bandwidth).
+  It was first thought to be the server's 5 ms `next` poll, but
+  shrinking that to 1 ms did not move it, and with zero seq gaps the
+  client provably receives every frame the camera produces.
+- **200 Hz verdict: reachable at bin 2** with windows up to ~200x140
+  binned pixels: 192-194 fps (96% efficiency) at 5 ms exposure, zero
+  drops. At bin 1 even 80x56 only reaches ~105 fps.
+- **Untested lever**: `ASI_BANDWIDTHOVERLOAD` (USB bandwidth %, SDK
+  default 40) is not exposed by zwoserver; raising it should shrink
+  the per-row readout cost and lift the camera-limited ceilings
+  above (including the ~5.15 ms floor).
+
+### Server fixes this benchmark motivated (zwoserver.c, 2026-07-08)
+
+- `TCP_NODELAY` on client sockets: cured a Nagle/delayed-ACK collapse
+  for frames under a few KB (40x28 bin 2 went from ~23 fps with 40 ms
+  stalls to 194 fps).
+- `next` poll quantum 5 ms -> 1 ms (removes 0-5 ms of per-frame jitter).
+- **aarch64 memory-ordering bug fixed**: `run_video` shared the video
+  buffer pointers and `video_seq` with the connection thread through
+  plain globals. On x86 (original deployment) this was benign; on the
+  Raspberry Pi the consumer could see `video_seq` tick before the new
+  buffer pointers, memcpy from a freed buffer, and crash the server
+  (SEGV confirmed by gdb backtraces). Buffers are now allocated in the
+  `start` handler on the connection thread and the seq handoff uses
+  `__sync_synchronize()` barriers. Faster command turnaround from
+  TCP_NODELAY is what exposed this latent bug.
+- Video thread lifetime serialized across stop/start, SDK buffers
+  padded (`SDK_BUF_PAD`), 350 ms settle after `ASIStopVideoCapture`,
+  and `Restart=on-failure` in `zwo.service`.
+- Validated: 4 consecutive full 96-config sweeps + tiny-ROI set
+  (396 configs, ~100 stop/setup/start transitions) with zero failures
+  and zero crashes under gdb.
+
+## TODO
+
+Sweep `ASI_BANDWIDTHOVERLOAD` once `zwoserver.c` exposes a command to
+set it (currently only exposure/gain/offset/cooler are wired).

--- a/src/benchmark/zwo_benchmark.c
+++ b/src/benchmark/zwo_benchmark.c
@@ -34,6 +34,7 @@
 #define MAX_EXPS   32
 #define MAX_BINS    8
 #define MAX_BITS    4
+#define MAX_ROIS    8
 #define CMD_BUF   512
 #define LINE_BUF 1024
 
@@ -49,6 +50,8 @@ typedef struct {
   int         bins[MAX_BINS];
   int         n_bit;
   int         bitdepths[MAX_BITS];
+  int         n_roi;
+  double      rois[MAX_ROIS];      /* window size, percent of full frame */
   int         gain, offset;
   int         have_gain, have_offset;
   const char *csv_path;
@@ -58,6 +61,8 @@ typedef struct {
 typedef struct {
   double exptime;
   int    bin, bits;
+  double roi_pct;
+  int    x, y;
   int    w, h;
   int    frames;
   double elapsed;
@@ -250,6 +255,8 @@ static void set_defaults(BenchCfg *c)
   int dbt[] = {8, 16};
   c->n_bit = (int)(sizeof(dbt) / sizeof(dbt[0]));
   memcpy(c->bitdepths, dbt, sizeof(dbt));
+  c->n_roi = 1;
+  c->rois[0] = 100.0;
 }
 
 static void usage(const char *prog)
@@ -261,6 +268,8 @@ static void usage(const char *prog)
 "  --exptimes CSV          (default: 0.001,0.005,0.01,0.05,0.1,0.5,1.0)\n"
 "  --bins CSV              (default: 1,2,4)\n"
 "  --bits CSV              (default: 8,16)\n"
+"  --rois CSV              window size as %% of full frame, centered\n"
+"                          (default: 100; e.g. 10,50,80,100)\n"
 "  --duration SEC          (default: 10.0)\n"
 "  --warmup SEC            (default: 3.0)\n"
 "  --next-timeout SEC      (default: 2.0)\n"
@@ -280,6 +289,7 @@ static int parse_args(int argc, char **argv, BenchCfg *c)
     {"exptimes",     required_argument, 0, 'e'},
     {"bins",         required_argument, 0, 'b'},
     {"bits",         required_argument, 0, 'B'},
+    {"rois",         required_argument, 0, 'r'},
     {"duration",     required_argument, 0, 'd'},
     {"warmup",       required_argument, 0, 'w'},
     {"next-timeout", required_argument, 0, 't'},
@@ -310,6 +320,17 @@ static int parse_args(int argc, char **argv, BenchCfg *c)
       if (n <= 0) { fprintf(stderr, "bad --bits\n"); return -1; }
       c->n_bit = n; break;
     }
+    case 'r': {
+      int n = parse_double_csv(optarg, c->rois, MAX_ROIS);
+      if (n <= 0) { fprintf(stderr, "bad --rois\n"); return -1; }
+      for (int i = 0; i < n; i++) {
+        if (c->rois[i] <= 0.0 || c->rois[i] > 100.0) {
+          fprintf(stderr, "bad --rois: %g not in (0,100]\n", c->rois[i]);
+          return -1;
+        }
+      }
+      c->n_roi = n; break;
+    }
     case 'd': c->duration_s = atof(optarg); break;
     case 'w': c->warmup_s = atof(optarg); break;
     case 't': c->next_timeout_s = atof(optarg); break;
@@ -339,22 +360,32 @@ static int parse_args(int argc, char **argv, BenchCfg *c)
  * on demand so we don't pay malloc cost per config. */
 static int run_one(int sock, const BenchCfg *cfg,
                    int W, int H, double exptime, int bin, int bits,
+                   double roi_pct,
                    u_char **buf, size_t *buf_cap, BenchRow *row)
 {
   memset(row, 0, sizeof(*row));
   row->exptime = exptime; row->bin = bin; row->bits = bits;
+  row->roi_pct = roi_pct;
   row->expected_fps = 1.0 / exptime;
 
-  int want_w = (W / bin) & ~7;
-  int want_h = (H / bin) & ~1;
+  /* Window of roi_pct % of the (binned) full frame, centered on the
+   * sensor.  Same 8/2 rounding as the server; offsets aligned too. */
+  int full_w = (W / bin) & ~7;
+  int full_h = (H / bin) & ~1;
+  int want_w = (int)(full_w * roi_pct / 100.0) & ~7;
+  int want_h = (int)(full_h * roi_pct / 100.0) & ~1;
+  if (want_w < 8) want_w = 8;
+  if (want_h < 2) want_h = 2;
+  int want_x = ((full_w - want_w) / 2) & ~7;
+  int want_y = ((full_h - want_h) / 2) & ~1;
 
   int ox, oy, ow, oh, obin, obits;
-  if (setup_roi(sock, 0, 0, want_w, want_h, bin, bits,
+  if (setup_roi(sock, want_x, want_y, want_w, want_h, bin, bits,
                 &ox, &oy, &ow, &oh, &obin, &obits) != 0) {
     snprintf(row->note, sizeof(row->note), "setup fail");
     return -1;
   }
-  row->w = ow; row->h = oh; row->bits = obits;
+  row->x = ox; row->y = oy; row->w = ow; row->h = oh; row->bits = obits;
   size_t nbytes = (size_t)ow * (size_t)oh * (size_t)(obits / 8);
   row->bytes_per_frame = nbytes;
 
@@ -400,6 +431,7 @@ static int run_one(int sock, const BenchCfg *cfg,
   int frames = 0, drops = 0, enodata = 0;
   double t0 = walltime(0);
   double t_end = t0 + cfg->duration_s;
+  double t_last = t0;
   while (!g_stop && walltime(0) < t_end) {
     int r = next_frame(sock, cfg->next_timeout_s, &seq, &temp, &power,
                        *buf, nbytes, recv_timeout_s);
@@ -411,7 +443,10 @@ static int run_one(int sock, const BenchCfg *cfg,
     if (!first && seq > last_seq + 1) drops += (int)(seq - last_seq - 1);
     last_seq = seq; first = 0; frames++;
     if (cfg->verbose) {
-      fprintf(stderr, "  seq=%u temp=%.1f power=%.0f\n", seq, temp, power);
+      double t_now = walltime(0);
+      fprintf(stderr, "  seq=%u dt=%.4f temp=%.1f power=%.0f\n",
+              seq, t_now - t_last, temp, power);
+      t_last = t_now;
     }
   }
   double elapsed = walltime(0) - t0;
@@ -448,8 +483,8 @@ static void print_session_banner(const BenchCfg *cfg, const char *model,
  * (allows `zwo_benchmark ... > results.txt` without losing feedback). */
 static void print_progress_start(int idx, int total, const BenchRow *r)
 {
-  fprintf(stderr, "[%2d/%2d] exptime=%.4f bin=%d bits=%d ... ",
-          idx, total, r->exptime, r->bin, r->bits);
+  fprintf(stderr, "[%2d/%2d] exptime=%.4f bin=%d bits=%d roi=%.0f%% ... ",
+          idx, total, r->exptime, r->bin, r->bits, r->roi_pct);
   fflush(stderr);
 }
 
@@ -469,25 +504,25 @@ static void print_progress_done(const BenchRow *r)
 static void print_table_separator(FILE *fp)
 {
   fprintf(fp,
-    "+--------+-----+------+------+------+--------+---------+---------"
+    "+--------+-----+------+-------+------+------+--------+---------+---------"
     "+---------+-------+------+---------+--------+--------------------+\n");
 }
 
 static void print_table_header(FILE *fp)
 {
   fprintf(fp,
-    "| %-6s | %-3s | %-4s | %-4s | %-4s | %-6s | %-7s | %-7s | %-7s | "
+    "| %-6s | %-3s | %-4s | %-5s | %-4s | %-4s | %-6s | %-7s | %-7s | %-7s | "
     "%-5s | %-4s | %-7s | %-6s | %-18s |\n",
-    "exptim", "bin", "bits", "W", "H", "frames", "elapsed", "fps",
+    "exptim", "bin", "bits", "roi%", "W", "H", "frames", "elapsed", "fps",
     "expFPS", "eff%", "drop", "enodata", "MB/s", "note");
 }
 
 static void print_table_row(FILE *fp, const BenchRow *r)
 {
   fprintf(fp,
-    "| %6.4f | %3d | %4d | %4d | %4d | %6d | %7.2f | %7.2f | %7.2f | "
+    "| %6.4f | %3d | %4d | %5.1f | %4d | %4d | %6d | %7.2f | %7.2f | %7.2f | "
     "%5.1f | %4d | %7d | %6.1f | %-18.18s |\n",
-    r->exptime, r->bin, r->bits, r->w, r->h,
+    r->exptime, r->bin, r->bits, r->roi_pct, r->w, r->h,
     r->frames, r->elapsed, r->fps, r->expected_fps,
     r->efficiency_pct, r->drops, r->enodata_count, r->mbps,
     r->note[0] ? r->note : "");
@@ -510,12 +545,12 @@ static int write_csv(const BenchRow *rows, int n, const char *path)
     fprintf(stderr, "csv: cannot open '%s': %s\n", path, strerror(errno));
     return -1;
   }
-  fprintf(fp, "exptime,bin,bits,w,h,frames,elapsed,fps,expected_fps,"
+  fprintf(fp, "exptime,bin,bits,roi_pct,x,y,w,h,frames,elapsed,fps,expected_fps,"
               "efficiency_pct,drops,enodata,bytes_per_frame,mbps,note\n");
   for (int i = 0; i < n; i++) {
     const BenchRow *r = &rows[i];
-    fprintf(fp, "%.6f,%d,%d,%d,%d,%d,%.4f,%.4f,%.4f,%.2f,%d,%d,%zu,%.3f,\"%s\"\n",
-            r->exptime, r->bin, r->bits, r->w, r->h,
+    fprintf(fp, "%.6f,%d,%d,%.2f,%d,%d,%d,%d,%d,%.4f,%.4f,%.4f,%.2f,%d,%d,%zu,%.3f,\"%s\"\n",
+            r->exptime, r->bin, r->bits, r->roi_pct, r->x, r->y, r->w, r->h,
             r->frames, r->elapsed, r->fps, r->expected_fps,
             r->efficiency_pct, r->drops, r->enodata_count,
             r->bytes_per_frame, r->mbps, r->note);
@@ -554,24 +589,27 @@ int main(int argc, char **argv)
 
   print_session_banner(&cfg, model, W, H, cooler, color, bitDepth);
 
-  int n_rows = cfg.n_bit * cfg.n_bin * cfg.n_exp;
+  int n_rows = cfg.n_bit * cfg.n_bin * cfg.n_roi * cfg.n_exp;
   BenchRow *rows = calloc((size_t)n_rows, sizeof(BenchRow));
   u_char *frame_buf = NULL;
   size_t  frame_cap = 0;
   int idx = 0, completed = 0;
   for (int bi = 0; bi < cfg.n_bit && !g_stop; bi++) {
     for (int ni = 0; ni < cfg.n_bin && !g_stop; ni++) {
-      for (int ei = 0; ei < cfg.n_exp && !g_stop; ei++) {
-        BenchRow *row = &rows[idx];
-        row->exptime = cfg.exptimes[ei];
-        row->bin     = cfg.bins[ni];
-        row->bits    = cfg.bitdepths[bi];
-        print_progress_start(idx + 1, n_rows, row);
-        (void)run_one(sock, &cfg, W, H,
-                      row->exptime, row->bin, row->bits,
-                      &frame_buf, &frame_cap, row);
-        print_progress_done(row);
-        completed = ++idx;
+      for (int ri = 0; ri < cfg.n_roi && !g_stop; ri++) {
+        for (int ei = 0; ei < cfg.n_exp && !g_stop; ei++) {
+          BenchRow *row = &rows[idx];
+          row->exptime = cfg.exptimes[ei];
+          row->bin     = cfg.bins[ni];
+          row->bits    = cfg.bitdepths[bi];
+          row->roi_pct = cfg.rois[ri];
+          print_progress_start(idx + 1, n_rows, row);
+          (void)run_one(sock, &cfg, W, H,
+                        row->exptime, row->bin, row->bits, row->roi_pct,
+                        &frame_buf, &frame_cap, row);
+          print_progress_done(row);
+          completed = ++idx;
+        }
       }
     }
   }

--- a/src/benchmark/zwo_benchmark.c
+++ b/src/benchmark/zwo_benchmark.c
@@ -10,9 +10,8 @@
  * sweep loop are complete. The per-configuration warmup +
  * measurement window is a stub and will be filled in next.
  *
- * TODO: sweep ASI_BANDWIDTHOVERLOAD once zwoserver.c exposes a
- *       command to set it (currently only EXPOSURE/GAIN/OFFSET/
- *       COOLER/TARGET_TEMP/FAN are wired through handle_asi()).
+ * ASI_BANDWIDTHOVERLOAD is set via the server's 'usb' command
+ * (--usb N, 40..100); sweep it by running once per value.
  *
  * ---------------------------------------------------------------- */
 
@@ -52,8 +51,8 @@ typedef struct {
   int         bitdepths[MAX_BITS];
   int         n_roi;
   double      rois[MAX_ROIS];      /* window size, percent of full frame */
-  int         gain, offset;
-  int         have_gain, have_offset;
+  int         gain, offset, usb, highspeed;
+  int         have_gain, have_offset, have_usb, have_highspeed;
   const char *csv_path;
   int         verbose;
 } BenchCfg;
@@ -275,6 +274,8 @@ static void usage(const char *prog)
 "  --next-timeout SEC      (default: 2.0)\n"
 "  --gain N                (optional)\n"
 "  --offset N              (optional)\n"
+"  --usb N                 ASI_BANDWIDTHOVERLOAD 40..100 (optional)\n"
+"  --highspeed N           ASI_HIGH_SPEED_MODE 0/1, 10-bit ADC (optional)\n"
 "  --csv PATH              (optional)\n"
 "  -v, --verbose\n"
 "  -h, --help\n", prog, SERVER_PORT);
@@ -295,6 +296,8 @@ static int parse_args(int argc, char **argv, BenchCfg *c)
     {"next-timeout", required_argument, 0, 't'},
     {"gain",         required_argument, 0, 'g'},
     {"offset",       required_argument, 0, 'o'},
+    {"usb",          required_argument, 0, 'u'},
+    {"highspeed",    required_argument, 0, 'S'},
     {"csv",          required_argument, 0, 'c'},
     {"verbose",      no_argument,       0, 'v'},
     {"help",         no_argument,       0, 'h'},
@@ -336,6 +339,8 @@ static int parse_args(int argc, char **argv, BenchCfg *c)
     case 't': c->next_timeout_s = atof(optarg); break;
     case 'g': c->gain = atoi(optarg); c->have_gain = 1; break;
     case 'o': c->offset = atoi(optarg); c->have_offset = 1; break;
+    case 'u': c->usb = atoi(optarg); c->have_usb = 1; break;
+    case 'S': c->highspeed = atoi(optarg); c->have_highspeed = 1; break;
     case 'c': c->csv_path = optarg; break;
     case 'v': c->verbose = 1; break;
     case 'h':
@@ -472,8 +477,11 @@ static void print_session_banner(const BenchCfg *cfg, const char *model,
                                  int W, int H, int cooler, int color,
                                  int bitDepth)
 {
-  printf("ZWO benchmark   host=%s:%d   duration=%.1fs   warmup=%.1fs\n",
+  printf("ZWO benchmark   host=%s:%d   duration=%.1fs   warmup=%.1fs",
          cfg->host, cfg->port, cfg->duration_s, cfg->warmup_s);
+  if (cfg->have_usb) printf("   usb=%d", cfg->usb);
+  if (cfg->have_highspeed) printf("   highspeed=%d", cfg->highspeed);
+  printf("\n");
   printf("camera: %s  %dx%d  cooler=%d color=%d bitDepth=%d\n\n",
          model, W, H, cooler, color, bitDepth);
   fflush(stdout);
@@ -586,6 +594,8 @@ int main(int argc, char **argv)
 
   if (cfg.have_gain)   set_int_control(sock, "gain",   cfg.gain);
   if (cfg.have_offset) set_int_control(sock, "offset", cfg.offset);
+  if (cfg.have_usb)    set_int_control(sock, "usb",    cfg.usb);
+  if (cfg.have_highspeed) set_int_control(sock, "highspeed", cfg.highspeed);
 
   print_session_banner(&cfg, model, W, H, cooler, color, bitDepth);
 

--- a/src/benchmark/zwo_benchmark.c
+++ b/src/benchmark/zwo_benchmark.c
@@ -179,12 +179,14 @@ static int recv_exact(int sock, u_char *buf, size_t nbytes, int timeout_s)
 }
 
 /* Fetch one video frame.
- *   return  0 : ok (seq/temp/power/buf populated)
+ *   return  0 : ok (seq/temp/power/ts_ns/buf populated)
  *   return  1 : server replied -Enodata (no frame within its own timeout)
  *   return <0 : error
- */
+ * ts_ns is the server-side CLOCK_REALTIME receive stamp (0 when the
+ * server predates protocol 1.0.5). */
 static int next_frame(int sock, double server_timeout_s,
                       unsigned int *seq, double *temp, double *power,
+                      unsigned long long *ts_ns,
                       u_char *buf, size_t nbytes, int recv_timeout_s)
 {
   char cmd[CMD_BUF], resp[LINE_BUF];
@@ -196,7 +198,9 @@ static int next_frame(int sock, double server_timeout_s,
     return -3;
   }
   int per = 0;
-  if (sscanf(resp, "%u %lf %d", seq, temp, &per) != 3) {
+  *ts_ns = 0;
+  int nf = sscanf(resp, "%u %lf %d %llu", seq, temp, &per, ts_ns);
+  if (nf < 3) {
     fprintf(stderr, "next: bad header '%s'\n", resp);
     return -4;
   }
@@ -412,6 +416,7 @@ static int run_one(int sock, const BenchCfg *cfg,
   int recv_timeout_s = (int)ceil(cfg->next_timeout_s + exptime + 1.0);
   unsigned int seq = 0, last_seq = 0;
   double temp = 0, power = 0;
+  unsigned long long ts_ns = 0, last_ts = 0;
 
   /* Warmup: discard frames for max(warmup_s, 5*exptime) AND >= 5 frames.
    * Covers TCP slow-start and any initial camera ramp. */
@@ -421,7 +426,7 @@ static int run_one(int sock, const BenchCfg *cfg,
   int warm = 0;
   while (!g_stop && (walltime(0) < t_warm_end || warm < 5)) {
     int r = next_frame(sock, cfg->next_timeout_s, &seq, &temp, &power,
-                       *buf, nbytes, recv_timeout_s);
+                       &ts_ns, *buf, nbytes, recv_timeout_s);
     if (r == 0) warm++;
     else if (r == 1) msleep(5);
     else {
@@ -439,7 +444,7 @@ static int run_one(int sock, const BenchCfg *cfg,
   double t_last = t0;
   while (!g_stop && walltime(0) < t_end) {
     int r = next_frame(sock, cfg->next_timeout_s, &seq, &temp, &power,
-                       *buf, nbytes, recv_timeout_s);
+                       &ts_ns, *buf, nbytes, recv_timeout_s);
     if (r == 1) { enodata++; msleep(5); continue; }
     if (r < 0) {
       snprintf(row->note, sizeof(row->note), "recv fail (%d)", r);
@@ -448,10 +453,13 @@ static int run_one(int sock, const BenchCfg *cfg,
     if (!first && seq > last_seq + 1) drops += (int)(seq - last_seq - 1);
     last_seq = seq; first = 0; frames++;
     if (cfg->verbose) {
+      /* dt = client-side arrival interval (protocol+network included),
+       * dts = server-side ASIGetVideoData interval (camera timing) */
       double t_now = walltime(0);
-      fprintf(stderr, "  seq=%u dt=%.4f temp=%.1f power=%.0f\n",
-              seq, t_now - t_last, temp, power);
-      t_last = t_now;
+      double dts = (last_ts && ts_ns) ? (double)(ts_ns - last_ts)/1e9 : 0.0;
+      fprintf(stderr, "  seq=%u dt=%.4f dts=%.4f ts=%llu temp=%.1f power=%.0f\n",
+              seq, t_now - t_last, dts, ts_ns, temp, power);
+      t_last = t_now; last_ts = ts_ns;
     }
   }
   double elapsed = walltime(0) - t0;

--- a/src/py/zwo_emulator.py
+++ b/src/py/zwo_emulator.py
@@ -478,7 +478,7 @@ class ZwoEmulator:
                     self.image_data = self.video_data
                     self.image_size = len(self.image_data) if self.image_data else 0
                     binary_data = self.image_data
-                    response = f"{self.video_last} {self.temperature:.1f} {self.cooler_power:.0f}"
+                    response = f"{self.video_last} {self.temperature:.1f} {self.cooler_power:.0f} {time.time_ns()}"
                 else:
                     response = "-Enodata"
                 

--- a/src/server/ASICamera2.h
+++ b/src/server/ASICamera2.h
@@ -1,6 +1,6 @@
 /**************************************************
 this is the second version of release ASI Camera ASIs
-any question feel free contact us:sam.wen@zwoptical.com
+any question feel free contact us:software@zwoptical.com
 
 here is the suggested procedure to operate the camera.
 
@@ -39,7 +39,7 @@ while(1)
 	#define ASICAMERA_API 
 #endif
 
-#define ASICAMERA_ID_MAX 128
+#define ASICAMERA_ID_MAX 256
 
 typedef enum ASI_BAYER_PATTERN{
 	ASI_BAYER_RG=0,
@@ -110,6 +110,11 @@ typedef enum ASI_ERROR_CODE{ //ASI ERROR CODE
 	ASI_ERROR_EXPOSURE_IN_PROGRESS,
 	ASI_ERROR_GENERAL_ERROR,//general error, eg: value is out of valid range
 	ASI_ERROR_INVALID_MODE,//the current mode is wrong
+	ASI_ERROR_GPS_NOT_SUPPORTED, //this camera do not support GPS
+	ASI_ERROR_GPS_VER_ERR, //the FPGA GPS ver is too low
+	ASI_ERROR_GPS_FPGA_ERR, //failed to read or write data to FPGA
+	ASI_ERROR_GPS_PARAM_OUT_OF_RANGE, //start line or end line out of range, should make them between 0 ~ MaxHeight - 1
+	ASI_ERROR_GPS_DATA_INVALID, //GPS has not yet found the satellite or FPGA cannot read GPS data
 	ASI_ERROR_END
 }ASI_ERROR_CODE;
 
@@ -170,7 +175,13 @@ typedef enum ASI_CONTROL_TYPE{ //Control type//
 	ASI_FAN_ON,
 	ASI_PATTERN_ADJUST,
 	ASI_ANTI_DEW_HEATER,
-
+	ASI_FAN_ADJUST,
+	ASI_PWRLED_BRIGNT,
+	ASI_USBHUB_RESET,
+	ASI_GPS_SUPPORT,
+	ASI_GPS_START_LINE,
+	ASI_GPS_END_LINE,
+	ASI_ROLLING_INTERVAL,//microsecond
 }ASI_CONTROL_TYPE;
 
 typedef struct _ASI_CONTROL_CAPS
@@ -203,6 +214,27 @@ typedef ASI_ID ASI_SN;
 typedef struct _ASI_SUPPORTED_MODE{
 	ASI_CAMERA_MODE SupportedCameraMode[16];// this array will content with the support camera mode type.ASI_MODE_END is the end of supported camera mode
 }ASI_SUPPORTED_MODE;
+
+typedef struct _ASI_DATE_TIME{
+	int Year; 
+	int Month; 
+	int Day;
+	int Hour;
+	int Minute;
+	int Second;
+	int Msecond;
+	int Usecond;  //Minimum Unit 0.1us, Maximum number 9999
+	char Unused[64]; //Using the Unused field to store concatenated strings
+} ASI_DATE_TIME;
+
+typedef struct _ASI_GPS_DATA {
+	ASI_DATE_TIME Datetime;
+	double Latitude;  // +: North Latitude -: South Latitude
+	double Longitude; // +: East longitude -: West longitude
+	int Altitude;     // Minimum Unit 0.1m, Maximum number 99999
+	int SatelliteNum; // Maximum number 99
+	char Unused[64];  
+} ASI_GPS_DATA;
 
 #ifndef __cplusplus
 #define ASI_CONTROL_TYPE int
@@ -237,8 +269,22 @@ Paras:
 int* pPIDs: pointer to array of PIDs
 
 Return: length of the array.
+
+Note: This api will be deprecated. Please use ASICameraCheck instead
 ***************************************************************************/
 ASICAMERA_API int ASIGetProductIDs(int* pPIDs);
+
+/***************************************************************************
+Descriptions:
+Check if the device is ASI Camera
+
+Paras:
+int iVID: VID is 0x03C3 for ASI Cameras
+int iPID: PID of the device
+
+Return: ASI_TRUE if the device is ASI Camera, otherwise ASI_FALSE
+***************************************************************************/
+ASICAMERA_API ASI_BOOL ASICameraCheck(int iVID, int iPID);
 
 /***************************************************************************
 Descriptions:
@@ -418,7 +464,8 @@ set the ROI area before capture.
 you must stop capture before call it.
 the width and height is the value after binning.
 ie. you need to set width to 640 and height to 480 if you want to run at 640X480@BIN2
-ASI120's data size must be times of 1024 which means width*height%1024=0
+Specially, ASI120's data size must be times of 1024 which means width*height%1024=0.
+
 Paras:		
 int CameraID: this is get from the camera property use the API ASIGetCameraProperty
 int iWidth,  the width of the ROI area. Make sure iWidth%8 == 0. 
@@ -621,6 +668,38 @@ ASICAMERA_API  ASI_ERROR_CODE ASIGetVideoData(int iCameraID, unsigned char* pBuf
 
 /***************************************************************************
 Descriptions:
+get data from the video buffer.the buffer is very small 
+you need to call this API as fast as possible, otherwise frame will be discarded
+so the best way is maintain one buffer loop and call this API in a loop
+please make sure the buffer size is biger enough to hold one image
+otherwise the this API will crash
+
+
+Paras:		
+int CameraID: this is get from the camera property use the API ASIGetCameraProperty
+unsigned char* pBuffer, caller need to malloc the buffer, make sure the size is big enough
+the size in byte:
+8bit mono:width*height
+16bit mono:width*height*2
+RGB24:width*height*3
+
+int iWaitms, this API will block and wait iWaitms to get one image. the unit is ms
+-1 means wait forever. this value is recommend set to exposure*2+500ms
+
+GPS_DATA *gpsData, if camera support GPS, the GPS data will pass to incomming parameter,
+the GPS data struct is define at the top of this file.
+
+return:
+ASI_SUCCESS : Operation is successful
+ASI_ERROR_CAMERA_CLOSED : camera didn't open
+ASI_ERROR_INVALID_ID  :no camera of this ID is connected or ID value is out of boundary
+ASI_ERROR_TIMEOUT: no image get and timeout
+***************************************************************************/
+ASICAMERA_API  ASI_ERROR_CODE ASIGetVideoDataGPS(int iCameraID, unsigned char* pBuffer, long lBuffSize, int iWaitms, ASI_GPS_DATA *gpsData);
+
+
+/***************************************************************************
+Descriptions:
 PulseGuide of the ST4 port on. this function only work on the module which have ST4 port
 
 
@@ -735,6 +814,33 @@ ASICAMERA_API  ASI_ERROR_CODE ASIGetDataAfterExp(int iCameraID, unsigned char* p
 
 /***************************************************************************
 Descriptions:
+get data after exposure.
+please make sure the buffer size is biger enough to hold one image
+otherwise the this API will crash
+
+
+Paras:		
+int CameraID: this is get from the camera property use the API ASIGetCameraProperty
+unsigned char* pBuffer, caller need to malloc the buffer, make sure the size is big enough
+the size in byte:
+8bit mono:width*height
+16bit mono:width*height*2
+RGB24:width*height*3
+
+GPS_DATA *gpsData, if camera support GPS, the GPS data will pass to incomming parameter,
+the GPS data struct is define at the top of this file.
+
+
+return:
+ASI_SUCCESS : Operation is successful
+ASI_ERROR_CAMERA_CLOSED : camera didn't open
+ASI_ERROR_INVALID_ID  :no camera of this ID is connected or ID value is out of boundary
+ASI_ERROR_TIMEOUT: no image get and timeout
+***************************************************************************/
+ASICAMERA_API  ASI_ERROR_CODE ASIGetDataAfterExpGPS(int iCameraID, unsigned char* pBuffer, long lBuffSize, ASI_GPS_DATA *gpsData);
+
+/***************************************************************************
+Descriptions:
 get camera id stored in flash, only available for USB3.0 camera
 
 Paras:		
@@ -778,6 +884,23 @@ ASI_ERROR_CAMERA_CLOSED : camera didn't open
 ASI_ERROR_INVALID_ID  :no camera of this ID is connected or ID value is out of boundary
 ***************************************************************************/
 ASICAMERA_API ASI_ERROR_CODE ASIGetGainOffset(int iCameraID, int *pOffset_HighestDR, int *pOffset_UnityGain, int *pGain_LowestRN, int *pOffset_LowestRN);
+
+/***************************************************************************
+Descriptions:
+get the frequently-used gain and offset
+Paras:		
+int CameraID: this is get from the camera property use the API ASIGetCameraProperty
+pLGain: Low gain
+pMGain: Middle Gain
+pHGain: High Gain, the gain at the lowest read noise
+pHOffset: Offset at the lowest read noise
+
+return:
+ASI_SUCCESS : Operation is successful
+ASI_ERROR_CAMERA_CLOSED : camera didn't open
+ASI_ERROR_INVALID_ID  :no camera of this ID is connected or ID value is out of boundary
+***************************************************************************/
+ASICAMERA_API ASI_ERROR_CODE ASIGetLMHGainOffset(int iCameraID, int* pLGain, int* pMGain, int* pHGain, int* pHOffset);
 
 /***************************************************************************
 Descriptions:
@@ -900,6 +1023,24 @@ ASI_ERROR_GENERAL_ERROR : the parameter is not right
 ***************************************************************************/
 ASICAMERA_API ASI_ERROR_CODE  ASIGetTriggerOutputIOConf(int iCameraID, ASI_TRIG_OUTPUT_PIN pin, ASI_BOOL *bPinHigh, long *lDelay, long *lDuration);
 
+/***************************************************************************
+Description:
+Get the GPS data
+Paras:
+int CameraID: this is get from the camera property use the API ASIGetCameraProperty.
+ASI_GPS_DATA* startLineGPSData: the GPS data of the start line. the start line number is set by ASISetControlValue(..., ASI_GPS_START_LINE,...). the default value is 0
+ASI_GPS_DATA* endLineGPSData: the GPS data of the end line. the end line number is set by ASISetControlValue(..., ASI_GPS_END_LINE,...). the default value is MaxHeight - 1
+
+return:
+ASI_SUCCESS : Operation is successful
+ASI_ERROR_CAMERA_CLOSED : camera didn't open
+ASI_ERROR_INVALID_ID  : no camera of this ID is connected or ID value is out of boundary
+ASI_ERROR_GPS_NOT_SUPPORTED : this camera do not support GPS
+ASI_ERROR_GPS_VER_ERR : the FPGA GPS ver is too low
+ASI_ERROR_GPS_FPGA_ERR : failed to read or write data to FPGA
+ASI_ERROR_GPS_DATA_INVALID : GPS has not yet found the satellite or FPGA cannot read GPS data
+***************************************************************************/
+ASICAMERA_API ASI_ERROR_CODE ASIGPSGetData(int iCameraID, ASI_GPS_DATA* startLineGPSData, ASI_GPS_DATA* endLineGPSData);
 #ifdef __cplusplus
 }
 #endif

--- a/src/server/utils.c
+++ b/src/server/utils.c
@@ -992,7 +992,7 @@ int put_string(const char* file,const char* key,char* string)
   char buffer[1024],comment[512],*lines[MAX_LINES],*h;
   FILE *fp;
  
-  fd = open(file,O_RDWR | O_CREAT);    /* open file read/write */
+  fd = open(file,O_RDWR | O_CREAT,00644);  /* open file read/write */
   if (fd == -1) {
     fprintf(stderr,"%s: put_string(%s,%s,%s): cannot open file\n",__FILE__,
             file,key,string);
@@ -1306,7 +1306,7 @@ int lockfile_open(const char* file)
   int  fd;
   char buf[32];
 
-  fd = open(file,O_RDWR | O_CREAT);    /* open lockfile */
+  fd = open(file,O_RDWR | O_CREAT,00644);  /* open lockfile */
   if (fd == -1) return(-1);            /* failed */
   if (lockf(fd,F_TLOCK,0) < 0) {       /* lock failed */
     close(fd);

--- a/src/server/zwo.h
+++ b/src/server/zwo.h
@@ -5,7 +5,7 @@
  * ---------------------------------------------------------------- */
 
 #define PROJECT_ID      23
-#define P_VERSION       "1.0.4"
+#define P_VERSION       "1.0.5"
 
 extern void message(const void*,const char*,int);
 

--- a/src/server/zwo.h
+++ b/src/server/zwo.h
@@ -5,7 +5,7 @@
  * ---------------------------------------------------------------- */
 
 #define PROJECT_ID      23
-#define P_VERSION       "1.0.5"
+#define P_VERSION       "1.0.6"       /* ASI SDK 1.41 */
 
 extern void message(const void*,const char*,int);
 

--- a/src/server/zwoserver.c
+++ b/src/server/zwoserver.c
@@ -41,9 +41,11 @@
 
 #include <sys/reboot.h>                /* requires server */
 #include <linux/reboot.h>              /* to run as 'root' */
+#include <netinet/in.h>                /* IPPROTO_TCP */
+#include <netinet/tcp.h>               /* TCP_NODELAY */
 
 #if (TIME_TEST > 0)
-#include <limits.h> 
+#include <limits.h>
 #include <sys/times.h>
 #include <unistd.h>
 #endif
@@ -88,6 +90,11 @@ static ASI_EXPOSURE_STATUS asi_exp_status=0;
 static u_char *asi_data=NULL;
 static u_char *video_data1=NULL,*video_data2=NULL; // v0024
 static u_int video_seq=0,video_last=0;
+static volatile int video_running=0;   /* run_video thread alive */
+/* safety margin on buffers passed to the SDK: ASIGetVideoData was
+ * observed to write past w*h*bytes at 16-bit large ROIs (ASI294MM Pro,
+ * SDK 1.20.2) corrupting the heap -> SEGV in a later realloc */
+#define SDK_BUF_PAD (1L<<20)
 static size_t asi_size=0;
 static double asi_startTime,asi_expTime;
 static int   asi_gain=0,asi_offset=10;
@@ -430,7 +437,7 @@ static int handle_asi(const char* command,char* answer,int buflen)
   } else
   if (!strcmp(cmd,"ASIGetDataAfterExp")) {
     asi_size = atoi(par1);
-    asi_data = (u_char*)realloc(asi_data,asi_size);
+    asi_data = (u_char*)realloc(asi_data,asi_size+SDK_BUF_PAD);
     int ret = ASIGetDataAfterExp(asi_id,asi_data,asi_size);
     // double t2 = walltime(0);
     // double dt = t2 - asi_startTime - asi_expTime;
@@ -445,7 +452,7 @@ static int handle_asi(const char* command,char* answer,int buflen)
   } else
   if (!strcmp(cmd,"ASIGetVideoData")) {
     asi_size = atoi(par1);
-    asi_data = (u_char*)realloc(asi_data,asi_size);
+    asi_data = (u_char*)realloc(asi_data,asi_size+SDK_BUF_PAD);
     int wait_ms = atoi(par2);
     double t1 = walltime(0);
     int ret = ASIGetVideoData(asi_id,asi_data,asi_size,wait_ms);
@@ -649,9 +656,10 @@ static int handle_command(const char* command,char* answer,size_t buflen)
       double t1 = walltime(0);
       while (video_seq <= video_last) {     /* b0025 */
 	if (walltime(0)-t1 >= timeout) break;
-        msleep(5); 
+        msleep(1);   /* 5ms quantum capped video at ~194 fps */
       }
-      if (video_seq > video_last) {      
+      if (video_seq > video_last) {
+        __sync_synchronize(); /* frame data written before seq (arm64) */
         video_last = video_seq;
         u_char *data = (video_last % 2) ? video_data2 : video_data1;
         asi_size = zwo_w * zwo_h * zwo_bits/8;
@@ -666,20 +674,34 @@ static int handle_command(const char* command,char* answer,size_t buflen)
   } else
   if (!strcasecmp(cmd,"start")) {
     if (zwo_state != ZWO_IDLE) err = E_not_idle;
-    if (!err) {
+    if (!err) { int i;   /* previous thread must be gone before its */
+                         /* buffers are realloc'ed for the new one  */
+      for (i=0; video_running && (i<300); i++) msleep(10);
       err = handle_asi("ASIStartVideoCapture",answer,buflen);
-      if (!err) {
+      if (!err) { size_t vsize = (size_t)zwo_w*zwo_h*zwo_bits/8;
+        /* buffers are (re)allocated HERE, on the thread that also   */
+        /* serves 'next': aarch64 reorders cross-thread stores, so a */
+        /* consumer must never read pointers written by run_video    */
+        video_data1 = (u_char*)realloc(video_data1,vsize+SDK_BUF_PAD);
+        video_data2 = (u_char*)realloc(video_data2,vsize+SDK_BUF_PAD);
         zwo_state = ZWO_VIDEO;
+        video_running = 1;
+        __sync_synchronize();
         thread_detach(run_video,NULL);  /* v0024 */
       }
     }
   } else
   if (!strcasecmp(cmd,"stop")) {
-    if (zwo_state == ZWO_VIDEO) {
+    if (zwo_state == ZWO_VIDEO) { int i;
       zwo_state = ZWO_IDLE;
+      /* wait for run_video to leave ASIGetVideoData() first: the SDK */
+      /* is not thread-safe and StopVideoCapture during GetVideoData  */
+      /* corrupts the heap (SEGV in a later realloc)                  */
+      for (i=0; video_running && (i<3000); i++) msleep(10);
       err = handle_asi("ASIStopVideoCapture",answer,buflen);
+      msleep(350);   /* let SDK worker threads settle, cf. 'start' */
     }
-  } else 
+  } else
   if (!strcasecmp(cmd,"write")) { 
     handle_command("data 0",answer,buflen);
     assert(asi_size == 0);
@@ -944,6 +966,9 @@ static void* run_tcpip(void* param)
     int on=1;
     (void)setsockopt(msgsock,SOL_SOCKET,SO_NOSIGPIPE,&on,sizeof(on));
 #endif
+    { int nd=1;      /* no Nagle delay on header+data sends of 'next' */
+      (void)setsockopt(msgsock,IPPROTO_TCP,TCP_NODELAY,&nd,sizeof(nd));
+    }
     sprintf(host,"%u.%u.%u.%u",
             (u_char)sadr.sa_data[2],(u_char)sadr.sa_data[3],
             (u_char)sadr.sa_data[4],(u_char)sadr.sa_data[5]);
@@ -980,9 +1005,8 @@ static void* run_video(void* param)
   u_char *data;
   char   buf[128];
 
-  video_data1 = (u_char*)realloc(video_data1,size);
-  video_data2 = (u_char*)realloc(video_data2,size);
-  
+  /* video_data1/2 are allocated by 'start' before this thread spawns */
+
   while (zwo_state == ZWO_VIDEO) {
     if (cor_time(0) < next) {   // v0026
       msleep(5);
@@ -996,10 +1020,13 @@ static void* run_video(void* param)
     // printf("writing to buffer %d\n",(data==video_data1) ? 1 : 2);
     ret = ASIGetVideoData(asi_id,data,size,wait);
     if (ret == ASI_SUCCESS) {
+      __sync_synchronize();  /* frame data visible before seq (arm64) */
       video_seq++;
     }
   }
   printf("%s done\n",PREFUN); //xxx
+  __sync_synchronize();
+  video_running = 0;
 
   return (void*)0;
 }

--- a/src/server/zwoserver.c
+++ b/src/server/zwoserver.c
@@ -112,13 +112,16 @@ static float asi_temperature,asi_target,asi_cooler_power;
 
 static const int efw_id=0;
 
-enum server_errors_enum { E_first=ASI_ERROR_END+1,
-                          E_no_camera,
+/* fixed base (was ASI_ERROR_END+1): SDK 1.41 added GPS error codes,
+ * shifting ASI_ERROR_END 18->23; clients (gcam/zwotcp.h, ZwoGUI,
+ * zwo_emulator.py) expect 20..25 on the wire */
+enum server_errors_enum { E_first=19,
+                          E_no_camera, /* 20 */
                           E_not_open,
                           E_not_idle,  /* 22 */
                           E_no_data,
 			  E_not_video,
-                          E_unknown,
+                          E_unknown,   /* 25 */
                           E_last };
 
 enum server_states_enum  { ZWO_CLOSED,

--- a/src/server/zwoserver.c
+++ b/src/server/zwoserver.c
@@ -43,6 +43,7 @@
 #include <linux/reboot.h>              /* to run as 'root' */
 #include <netinet/in.h>                /* IPPROTO_TCP */
 #include <netinet/tcp.h>               /* TCP_NODELAY */
+#include <time.h>                      /* clock_gettime() */
 
 #if (TIME_TEST > 0)
 #include <limits.h>
@@ -91,6 +92,12 @@ static u_char *asi_data=NULL;
 static u_char *video_data1=NULL,*video_data2=NULL; // v0024
 static u_int video_seq=0,video_last=0;
 static volatile int video_running=0;   /* run_video thread alive */
+/* per-frame receive timestamp [ns], [0]=video_data1 [1]=video_data2.
+ * CLOCK_REALTIME so two NTP/PTP-synced hosts can be cross-correlated
+ * on absolute time; switch to CLOCK_TAI on PTP deployments to be
+ * immune to leap-second steps. */
+#define TS_CLOCK CLOCK_REALTIME
+static unsigned long long video_ts[2];
 /* safety margin on buffers passed to the SDK: ASIGetVideoData was
  * observed to write past w*h*bytes at 16-bit large ROIs (ASI294MM Pro,
  * SDK 1.20.2) corrupting the heap -> SEGV in a later realloc */
@@ -685,8 +692,9 @@ static int handle_command(const char* command,char* answer,size_t buflen)
         asi_size = zwo_w * zwo_h * zwo_bits/8;
         asi_data = (u_char*)realloc(asi_data,asi_size);
         memcpy(asi_data,data,asi_size); // don't shift here v0028 
-        sprintf(answer,"%u %.1f %.0f",video_last,
-                asi_temperature,asi_cooler_power);
+        sprintf(answer,"%u %.1f %.0f %llu",video_last,
+                asi_temperature,asi_cooler_power,
+                video_ts[(video_last % 2) ? 1 : 0]);
       } else {
         strcpy(answer,"-Enodata");
       }
@@ -1018,6 +1026,16 @@ static void* run_tcpip(void* param)
 
 /* ---------------------------------------------------------------- */
 
+static unsigned long long time_ns(void) /* TS_CLOCK in nanoseconds */
+{
+  struct timespec tp;
+  clock_gettime(TS_CLOCK,&tp);
+  return (unsigned long long)tp.tv_sec*1000000000ull
+       + (unsigned long long)tp.tv_nsec;
+}
+
+/* ---------------------------------------------------------------- */
+
 static void* run_video(void* param)
 {
   int    wait,ret,size=zwo_w*zwo_h*zwo_bits/8;
@@ -1044,7 +1062,8 @@ static void* run_video(void* param)
     // printf("writing to buffer %d\n",(data==video_data1) ? 1 : 2);
     ret = ASIGetVideoData(asi_id,data,size,wait);
     if (ret == ASI_SUCCESS) {
-      __sync_synchronize();  /* frame data visible before seq (arm64) */
+      video_ts[(video_seq % 2) ? 0 : 1] = time_ns(); /* slot of 'data' */
+      __sync_synchronize();  /* frame data+ts visible before seq (arm64) */
       video_seq++;
     }
   }

--- a/src/server/zwoserver.c
+++ b/src/server/zwoserver.c
@@ -98,6 +98,8 @@ static volatile int video_running=0;   /* run_video thread alive */
 static size_t asi_size=0;
 static double asi_startTime,asi_expTime;
 static int   asi_gain=0,asi_offset=10;
+static int   asi_usb=40;               /* ASI_BANDWIDTHOVERLOAD, SDK default */
+static int   asi_highspeed=0;          /* ASI_HIGH_SPEED_MODE (10-bit ADC) */
 static int   asi_cooler;
 static float asi_temperature,asi_target,asi_cooler_power;
 
@@ -600,6 +602,24 @@ static int handle_command(const char* command,char* answer,size_t buflen)
     }
     if (!err) sprintf(answer,"%d",asi_offset);
   } else
+  if (!strcasecmp(cmd,"usb")) {        /* ASI_BANDWIDTHOVERLOAD 40..100 */
+    if (zwo_state == ZWO_CLOSED) err = E_not_open;
+    if (!err && (n > 1)) {
+      asi_usb = atoi(par1);
+      sprintf(buf,"ASISetControlValue %d %d",ASI_BANDWIDTHOVERLOAD,asi_usb);
+      err = handle_asi(buf,answer,buflen);
+    }
+    if (!err) sprintf(answer,"%d",asi_usb);
+  } else
+  if (!strcasecmp(cmd,"highspeed")) {  /* ASI_HIGH_SPEED_MODE 0/1 */
+    if (zwo_state == ZWO_CLOSED) err = E_not_open;
+    if (!err && (n > 1)) {
+      asi_highspeed = atoi(par1);
+      sprintf(buf,"ASISetControlValue %d %d",ASI_HIGH_SPEED_MODE,asi_highspeed);
+      err = handle_asi(buf,answer,buflen);
+    }
+    if (!err) sprintf(answer,"%d",asi_highspeed);
+  } else
   if (!strcasecmp(cmd,"status")) {
     if (zwo_state == ZWO_EXPOSING) { int a,b;
       handle_asi("ASIGetExpStatus",answer,buflen);
@@ -1014,7 +1034,11 @@ static void* run_video(void* param)
       handle_command("tempcon",buf,sizeof(buf));
       next = cor_time(0)+30; // TODO every 30 seconds
     }
-    wait = 350+(int)(1000.0*asi_expTime); 
+    /* keep the GetVideoData timeout short: the SDK's CirBuf::ReadBuff
+     * occasionally misses a wakeup and sleeps the FULL timeout even
+     * though the frame is ready (366ms stalls with the old 350ms
+     * floor; stall length tracks this value) */
+    wait = 50+(int)(1000.0*asi_expTime);
     // printf("wait=%d, size=%u, seq=%u\n",wait,size,video_seq);
     data = (video_seq % 2) ? video_data1 : video_data2;
     // printf("writing to buffer %d\n",(data==video_data1) ? 1 : 2);


### PR DESCRIPTION
## Summary
- Per-frame nanosecond timestamps (`next` returns `ts_ns`, CLOCK_REALTIME) for cross-camera correlation work (zwoserver 1.0.5)
- **ASI SDK 1.20.2 → 1.41**: new ASI715MC finder cameras enumerate as 0 cameras under 1.20.2, so `open` failed with `-Eerr=20` (E_no_camera). SDK 1.41 recognizes them.
- Server error enum base pinned to 19: the 1.41 header inserts five GPS error codes before `ASI_ERROR_END`, which would have shifted the wire error codes (20–25) that gcam, ZwoGUI and the python emulator hardcode. zwoserver never calls GPS APIs, so the overlapping SDK codes cannot reach the wire.
- Version bump to 1.0.6.

## Test plan
- Full Docker build (same as CI) passes; `zwoserver` links `libASICamera2.so → .so.1.41` in the installer bundle
- Deployed to zwoserver01: v1.0.6 running, SDK reports 1.41.0.0, attached camera enumerates
- Verify `open` succeeds with an ASI715MC attached; check video mode on an ASI294MM host before fleet rollout