### PR TITLE
gcam: add "status" command to the TCP/IP interface

### DIFF
--- a/docs/ZWO/index.html
+++ b/docs/ZWO/index.html
@@ -753,6 +753,33 @@ xterm&gt; nc localhost 52201
 <dd>returns "OK". </dd>
 <dt><b>version</b> </dt>
 <dd>returns "0.322" </dd>
+<dt><b>status</b> </dt>
+<dd>returns the current guider state as a single line of
+<tt>key=value</tt> pairs, separated by blanks, e.g.<br>
+<tt>init=1 loop=1 guiding=3 gm=1 fm=1 mm=1 exptime=0.100 av=0 gain=300
+offset=50 send=0 temp=-15.0 setp=-15 cooler=42 cfps=9.98 gfps=9.87
+fwhm=1.23 flux=123456 peak=45678 back=1234 dx=+0.12 dy=-0.34 az=+0.051
+el=-0.024 x=256.0 y=256.0 bx=15 px=196 pa=45.0 sn=1.0</tt> </dd>
+<dd><tt>init</tt>: camera initialized (0/1) &ndash;
+<tt>loop</tt>: acquisition loop running (0/1) &ndash;
+<tt>guiding</tt>: 0=off, 2..5 = active mode (&lt;F2&gt;..&lt;F5&gt;),
+negative while the first correction is still pending &ndash;
+<tt>gm</tt>/<tt>fm</tt>/<tt>mm</tt>: guide/function/mouse mode &ndash;
+<tt>av</tt>: rolling average &ndash;
+<tt>send</tt>: send flag &ndash;
+<tt>temp</tt>/<tt>setp</tt>/<tt>cooler</tt>: last values read by the
+housekeeping thread (stale if the cooler is off) &ndash;
+<tt>cfps</tt>: camera frame rate, <tt>gfps</tt>: guider loop rate &ndash;
+<tt>peak</tt>: peak pixel &ndash;
+<tt>dx</tt>/<tt>dy</tt>: centroid offset [pixels] &ndash;
+<tt>az</tt>/<tt>el</tt>: last guider correction [arcsec] &ndash;
+<tt>x</tt>/<tt>y</tt>: guide box center [pixels], <tt>bx</tt>: box size &ndash;
+<tt>px</tt>: pixel scale [mas] &ndash; <tt>pa</tt>: position angle &ndash;
+<tt>sn</tt>: sensitivity. </dd>
+<dd>The photometry fields (<tt>fwhm</tt>, <tt>flux</tt>, <tt>peak</tt>,
+<tt>back</tt>, <tt>dx</tt>, <tt>dy</tt>, <tt>az</tt>, <tt>el</tt>,
+<tt>gfps</tt>) hold the last measurement; they are only updated while
+guiding. </dd>
 </dl>
 
 <p>

--- a/docs/ZWO/zwogcam.html
+++ b/docs/ZWO/zwogcam.html
@@ -751,6 +751,33 @@ xterm&gt; nc localhost 52201
 <dd>returns "OK". </dd>
 <dt><b>version</b> </dt>
 <dd>returns "0.322" </dd>
+<dt><b>status</b> </dt>
+<dd>returns the current guider state as a single line of
+<tt>key=value</tt> pairs, separated by blanks, e.g.<br>
+<tt>init=1 loop=1 guiding=3 gm=1 fm=1 mm=1 exptime=0.100 av=0 gain=300
+offset=50 send=0 temp=-15.0 setp=-15 cooler=42 cfps=9.98 gfps=9.87
+fwhm=1.23 flux=123456 peak=45678 back=1234 dx=+0.12 dy=-0.34 az=+0.051
+el=-0.024 x=256.0 y=256.0 bx=15 px=196 pa=45.0 sn=1.0</tt> </dd>
+<dd><tt>init</tt>: camera initialized (0/1) &ndash;
+<tt>loop</tt>: acquisition loop running (0/1) &ndash;
+<tt>guiding</tt>: 0=off, 2..5 = active mode (&lt;F2&gt;..&lt;F5&gt;),
+negative while the first correction is still pending &ndash;
+<tt>gm</tt>/<tt>fm</tt>/<tt>mm</tt>: guide/function/mouse mode &ndash;
+<tt>av</tt>: rolling average &ndash;
+<tt>send</tt>: send flag &ndash;
+<tt>temp</tt>/<tt>setp</tt>/<tt>cooler</tt>: last values read by the
+housekeeping thread (stale if the cooler is off) &ndash;
+<tt>cfps</tt>: camera frame rate, <tt>gfps</tt>: guider loop rate &ndash;
+<tt>peak</tt>: peak pixel &ndash;
+<tt>dx</tt>/<tt>dy</tt>: centroid offset [pixels] &ndash;
+<tt>az</tt>/<tt>el</tt>: last guider correction [arcsec] &ndash;
+<tt>x</tt>/<tt>y</tt>: guide box center [pixels], <tt>bx</tt>: box size &ndash;
+<tt>px</tt>: pixel scale [mas] &ndash; <tt>pa</tt>: position angle &ndash;
+<tt>sn</tt>: sensitivity. </dd>
+<dd>The photometry fields (<tt>fwhm</tt>, <tt>flux</tt>, <tt>peak</tt>,
+<tt>back</tt>, <tt>dx</tt>, <tt>dy</tt>, <tt>az</tt>, <tt>el</tt>,
+<tt>gfps</tt>) hold the last measurement; they are only updated while
+guiding. </dd>
 </dl>
 
 <p>

--- a/docs/ZWO/zwoguider.html
+++ b/docs/ZWO/zwoguider.html
@@ -751,6 +751,33 @@ xterm&gt; nc localhost 52201
 <dd>returns "OK". </dd>
 <dt><b>version</b> </dt>
 <dd>returns "0.322" </dd>
+<dt><b>status</b> </dt>
+<dd>returns the current guider state as a single line of
+<tt>key=value</tt> pairs, separated by blanks, e.g.<br>
+<tt>init=1 loop=1 guiding=3 gm=1 fm=1 mm=1 exptime=0.100 av=0 gain=300
+offset=50 send=0 temp=-15.0 setp=-15 cooler=42 cfps=9.98 gfps=9.87
+fwhm=1.23 flux=123456 peak=45678 back=1234 dx=+0.12 dy=-0.34 az=+0.051
+el=-0.024 x=256.0 y=256.0 bx=15 px=196 pa=45.0 sn=1.0</tt> </dd>
+<dd><tt>init</tt>: camera initialized (0/1) &ndash;
+<tt>loop</tt>: acquisition loop running (0/1) &ndash;
+<tt>guiding</tt>: 0=off, 2..5 = active mode (&lt;F2&gt;..&lt;F5&gt;),
+negative while the first correction is still pending &ndash;
+<tt>gm</tt>/<tt>fm</tt>/<tt>mm</tt>: guide/function/mouse mode &ndash;
+<tt>av</tt>: rolling average &ndash;
+<tt>send</tt>: send flag &ndash;
+<tt>temp</tt>/<tt>setp</tt>/<tt>cooler</tt>: last values read by the
+housekeeping thread (stale if the cooler is off) &ndash;
+<tt>cfps</tt>: camera frame rate, <tt>gfps</tt>: guider loop rate &ndash;
+<tt>peak</tt>: peak pixel &ndash;
+<tt>dx</tt>/<tt>dy</tt>: centroid offset [pixels] &ndash;
+<tt>az</tt>/<tt>el</tt>: last guider correction [arcsec] &ndash;
+<tt>x</tt>/<tt>y</tt>: guide box center [pixels], <tt>bx</tt>: box size &ndash;
+<tt>px</tt>: pixel scale [mas] &ndash; <tt>pa</tt>: position angle &ndash;
+<tt>sn</tt>: sensitivity. </dd>
+<dd>The photometry fields (<tt>fwhm</tt>, <tt>flux</tt>, <tt>peak</tt>,
+<tt>back</tt>, <tt>dx</tt>, <tt>dy</tt>, <tt>az</tt>, <tt>el</tt>,
+<tt>gfps</tt>) hold the last measurement; they are only updated while
+guiding. </dd>
 </dl>
 
 <p>

--- a/src/gcam/guider.h
+++ b/src/gcam/guider.h
@@ -30,7 +30,7 @@ typedef struct guider_tag {
   float         stored_tf1,stored_tf3; /* v0329 */
   int           stored_send,stored_av,stored_mode;
   char          lastCommand[256];
-  char          command_msg[128];      /* v0333 */
+  char          command_msg[512];      /* v0333, enlarged for "status" */
   int           slitW;                 /* v0408 */
   double        north;                 /* v0419 */
   /* GUI */

--- a/src/gcam/zwogcam.c
+++ b/src/gcam/zwogcam.c
@@ -1624,6 +1624,35 @@ static int handle_command(Guider* g,const char* command,int showMsg)
     }
 #endif
   } else 
+  if (!strcasecmp(cmd,"status")) {     /* report guider state */
+    QlTool *q = g->qltool;
+    double fps,flux,ppix,back,fwhm,dx,dy,azg,elg;
+    float  gx,gy;
+    int    guiding;
+    pthread_mutex_lock(&g->mutex);     /* latch -- do not clear update_flag */
+    fps  = g->fps;  flux = g->flux; ppix = g->ppix;
+    back = g->back; fwhm = g->fwhm;
+    dx   = g->dx;   dy   = g->dy;      /* relative to the guide box */
+    azg  = g->azg;  elg  = g->elg;
+    guiding = q->guiding;              /* also set under 'mutex' */
+    gx = q->curx[QLT_BOX];             /* box follows the star in gm4/gm5 */
+    gy = q->cury[QLT_BOX];
+    pthread_mutex_unlock(&g->mutex);
+    snprintf(msgstr,sizeof(g->command_msg),
+      "init=%d loop=%d guiding=%d gm=%d fm=%d mm=%d "
+      "exptime=%.3f av=%d gain=%d offset=%d send=%d "
+      "temp=%.1f setp=%.0f cooler=%.0f cfps=%.2f gfps=%.2f "
+      "fwhm=%.2f flux=%.0f peak=%.0f back=%.0f dx=%+.2f dy=%+.2f "
+      "az=%+.3f el=%+.3f x=%.1f y=%.1f bx=%d px=%.0f pa=%.1f sn=%.1f",
+      g->init_flag,(int)g->loop_running,guiding,g->gmode,g->fmode,g->msmode,
+      g->status.exptime,g->server->rolling,g->server->gain,g->server->offset,
+      g->send_flag,
+      g->server->tempSensor,g->server->tempSetpoint,g->server->coolerPercent,
+      g->server->fps,fps,
+      fwhm,flux,ppix,back,dx,dy,
+      azg,elg,gx,gy,1+2*q->vrad,
+      1000.0*g->px,g->pa,g->sens);
+  } else
   if (!strncasecmp(cmd,"start",4)) {   /* start exposure loop */
     int r = do_start(g,0);
     if (r < 0) err = -r;
@@ -1709,7 +1738,10 @@ static int handle_command(Guider* g,const char* command,int showMsg)
   }
   if (err == 0) {                      /* no error */
     if (showMsg) {             /* show messages on display v0333 */
-      if (*msgstr) message(g,msgstr,MSS_WINDOW);
+      if (*msgstr) { char line[96];   /* EditWindow text is limited */
+        snprintf(line,sizeof(line),"%s",msgstr);
+        message(g,line,MSS_WINDOW);
+      }
       strcpy(g->lastCommand,command);
     }
   } else {                             /* error occured */
@@ -2793,6 +2825,8 @@ static int read_inifile(Guider *g,const char* name) /* v0415 */
 
 /* ---------------------------------------------------------------- */
 
+/* 'answer' must hold at least sizeof(g->command_msg)+4 bytes */
+
 static int handle_tcpip(Guider *g,const char* command,char* answer)
 {
   char cmd[128]="",par[128]="";
@@ -2850,7 +2884,7 @@ static void* run_tcpip(void* param)
   Guider *g = (Guider*)param;
   int    port = TCPIP_PORT + g->gnum;
   int    err,msgsock,rval;
-  char   cmd[128],buf[128];
+  char   cmd[128],buf[sizeof(g->command_msg)+4];
   IP_Address ip;
 #if (DEBUG > 0)
   fprintf(stderr,"%s:%s(%d)\n",__FILE__,PREFUN,port);


### PR DESCRIPTION
## Problem

The guider GUI's TCP/IP server (port `52200+gnum`, [`run_tcpip()`](https://github.com/carnegie-observatories/zwo/blob/main/src/gcam/zwogcam.c)) accepts commands but has no way to *read back* state. Every field a client might want — guiding on/off, `dx`/`dy`, `fwhm`, `flux`, `fps` — lives in the `Guider` struct and is only ever rendered into GUI edit boxes. The existing commands that return anything (`version`, `bx`, `lmag`, `dt`, `sw`, `gain`, `parity`) cover configuration, not state.

Until now the only way out was the EDS/TCSIS push path (`eds_send801`/`eds_send82i`) or scraping the GUI.

## Change

Adds a `status` command that returns one line of `key=value` pairs:

```
init=1 loop=1 guiding=3 gm=4 fm=1 mm=1 exptime=0.030 av=0 gain=0 offset=10 send=0
temp=-10.0 setp=2 cooler=50 cfps=9.48 gfps=9.77 fwhm=0.32 flux=92069 peak=778
back=75 dx=+1.18 dy=+4.58 az=+0.040 el=+0.009 x=756.0 y=756.0 bx=41 px=54
pa=-241.0 sn=0.5
```

- `guiding` — 0 = off, 2..5 = active mode (`<F2>`..`<F5>`), negative while the first correction is still pending
- `dx`/`dy` in pixels, `az`/`el` in arcsec, `px` in mas (the same units the `px` command takes)
- `cfps` is the camera frame rate, `gfps` the guider loop rate
- the photometry fields hold the last measurement and only update while guiding

The values are latched under `g->mutex` **without** clearing `update_flag`, so polling does not starve the GUI's own latch in `run_cycle()`. The cooler fields are the cached housekeeping values, so a poll never triggers a round-trip to the rPi.

## Buffer fixes pulled in by this

- `command_msg` 128 → 512 bytes. The reply is ~262 bytes typical. This also closes a pre-existing latent overflow: `sprintf(msgstr,"config file '%s' not found",inifile)` formats a 256-byte path into that buffer.
- `handle_command()` now truncates `msgstr` to 96 chars before `message()`, since `EditWindow.text` is 128 bytes including the timestamp prefix. Typing `status` in the GUI command box shows a clipped line; the TCP reply is complete.
- `run_tcpip()` sizes its reply buffer from `sizeof(command_msg)` rather than a hardcoded 128.

## Testing

Built clean (no new warnings). Run against `src/py/zwo_emulator.py` with `etc/ini/test.ini`:

```
$ nc 127.0.0.1 52203
version
1.0.6
status
init=1 loop=1 guiding=3 gm=4 ... sn=0.5
fone
OK
status
init=1 loop=1 guiding=0 gm=4 ...        <- guiding 3 -> 0
bogus
-Eunknown command: bogus
```

Not yet exercised against a real camera at the telescope.

## Notes

- Documented in the TCP/IP section of `docs/ZWO/{index,zwogcam,zwoguider}.html`.
- The interface is single-connection and `handle_tcpip()` sleeps 150 ms per command, so this is fine for a ~1 Hz status poll but not for high-rate telemetry.
- Left alone but worth a follow-up: `tec` with no argument reads the cooler correctly but reports via `message()` instead of `msgstr`, so over TCP it returns `OK` instead of the temperature. Now largely redundant with `status`.